### PR TITLE
added wicket-bundle project to use wicket in osgi env

### DIFF
--- a/jdk-1.5-parent/pom.xml
+++ b/jdk-1.5-parent/pom.xml
@@ -50,6 +50,7 @@
 		<module>shiro-security</module>
 		<module>simile-timeline-parent</module>
 		<module>theme-parent</module>
+    <module>wicket-bundle-parent</module>
 		<module>wicket-poi-parent</module>
 		<module>wicket-security-parent</module>
 		<module>wicketstuff-logback-parent</module>

--- a/jdk-1.5-parent/wicket-bundle-parent/pom.xml
+++ b/jdk-1.5-parent/wicket-bundle-parent/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>jdk-1.5-parent</artifactId>
+    <groupId>org.wicketstuff</groupId>
+    <version>1.5-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.wicketstuff</groupId>
+  <artifactId>wicket-bundle-parent</artifactId>
+
+  <packaging>pom</packaging>
+  
+  <name>wicket-bundle-parent</name>
+
+  <modules>
+    <module>wicket-bundle</module>
+  </modules>
+  
+</project>

--- a/jdk-1.5-parent/wicket-bundle-parent/wicket-bundle/pom.xml
+++ b/jdk-1.5-parent/wicket-bundle-parent/wicket-bundle/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.wicketstuff</groupId>
+    <artifactId>wicket-bundle-parent</artifactId>
+    <version>1.5-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>wicket-bundle</artifactId>
+  <name>Wicket Bundle</name>
+
+  <packaging>bundle</packaging>
+  
+  <description>
+	A module that creates a .jar from the classes in wicket, wicket-util and wicket-request modules in order
+  to create a valid OSGi bundle of the wicket framework.
+  </description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-core</artifactId>
+      <version>${wicket.version}</version>
+      <scope>provided</scope>
+      <classifier>sources</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-util</artifactId>
+      <version>${wicket.version}</version>
+      <scope>provided</scope>
+      <classifier>sources</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-request</artifactId>
+      <version>${wicket.version}</version>
+      <scope>provided</scope>
+      <classifier>sources</classifier>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.2.1</version>
+        <configuration>
+          <descriptors>
+            <descriptor>src/assembly/sources.xml</descriptor>
+          </descriptors>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-sources</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.4</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>org.apache.wicket.*</Import-Package>
+            <Export-Package>org.apache.wicket.*;version=${project.version};-split-package:=merge-first</Export-Package>
+            <DynamicImport-Package>*</DynamicImport-Package>
+            <Embed-Dependency>*;scope=compile;type=!pom;classifier=!sources;inline=true</Embed-Dependency>
+            <Embed-Transitive>false</Embed-Transitive>
+            <_nouses>true</_nouses>
+            <_failok>true</_failok>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jdk-1.5-parent/wicket-bundle-parent/wicket-bundle/src/assembly/sources.xml
+++ b/jdk-1.5-parent/wicket-bundle-parent/wicket-bundle/src/assembly/sources.xml
@@ -1,0 +1,24 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+
+ <id>sources</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>*:sources</include>
+      </includes>
+      <scope>provided</scope>
+      <unpack>true</unpack>
+      <useProjectArtifact>false</useProjectArtifact>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <useTransitiveFiltering>false</useTransitiveFiltering>
+    </dependencySet>
+  </dependencySets>
+
+</assembly>


### PR DESCRIPTION
Referring to the thread on the users mailling list:

 http://apache-wicket.1842946.n4.nabble.com/wicket-1-5-rc2-and-aggregate-jar-for-osgi-td3356667.html

This will add a new project that only contains pom files to repackage wicket for osgi.
