### PR TITLE
Bug fix "SForm component has not passed model to a super-class."

### DIFF
--- a/jdk-1.5-parent/scala-extensions-parent/wicket-scala/src/main/scala/org/wicketstuff/scala/SimpleComponents.scala
+++ b/jdk-1.5-parent/scala-extensions-parent/wicket-scala/src/main/scala/org/wicketstuff/scala/SimpleComponents.scala
@@ -13,7 +13,7 @@ import org.apache.wicket.markup.html.link.Link
 import org.apache.wicket.markup.html.list.{ListView, ListItem, PropertyListView}
 import org.apache.wicket.model.{IModel, Model}
 
-class SForm[T](id:String, model:IModel[T] , onSubmitFunc: ⇒ Unit) extends Form[T](id) {
+class SForm[T](id:String, model:IModel[T] , onSubmitFunc: ⇒ Unit) extends Form[T](id, model:IModel[T]) {
 
   override def onSubmit = onSubmitFunc
 

--- a/jdk-1.5-parent/scala-extensions-parent/wicket-scala/src/test/scala/org/wicketstuff/scala/ComponentSpecs.scala
+++ b/jdk-1.5-parent/scala-extensions-parent/wicket-scala/src/test/scala/org/wicketstuff/scala/ComponentSpecs.scala
@@ -92,6 +92,10 @@ class ComponentSpecs extends SpecificationWithJUnit with ScalaTest with ScalaWic
       def fx = sf.onSubmit
       clickCountUpdatingFunction(fx)
     }
+    "pass model to a super-class" in {
+      val sf = new SForm("form", new Fodel[String]("test"), {})
+      sf.getModelObject mustEq "test"
+    }
   }
   "SListView component" should { doBefore{ new WicketTester() }
     "take a closure for the #populateItem method" in {


### PR DESCRIPTION
In wicket-scala, SForm component has not passed model to a super-class.

Therefore, CompoundPropertyModel etc. do not work. 
