### PR TITLE
Wrapped ModalWindow in Form to avoid issues with IE

### DIFF
--- a/jdk-1.5-parent/modalx-parent/modalx/src/main/java/org/wicketstuff/modalx/optional/ModalXPage.html
+++ b/jdk-1.5-parent/modalx-parent/modalx/src/main/java/org/wicketstuff/modalx/optional/ModalXPage.html
@@ -3,9 +3,15 @@
         <title>Wicket ModalX Example</title>
     </head>
     <body>
-        <div wicket:id="modalWindow_0"></div>
-        <div wicket:id="modalWindow_1"></div>
-        <div wicket:id="modalWindow_2"></div>
+	<form wicket:id="wrapperForm_0">
+		<div wicket:id="modalWindow_0"></div>
+	</form>
+	<form wicket:id="wrapperForm_1">
+		<div wicket:id="modalWindow_1"></div>
+	</form>
+	<form wicket:id="wrapperForm_2">
+		<div wicket:id="modalWindow_2"></div>
+	</form>
 
         <wicket:child>
         </wicket:child>

--- a/jdk-1.5-parent/modalx-parent/modalx/src/main/java/org/wicketstuff/modalx/optional/ModalXPage.java
+++ b/jdk-1.5-parent/modalx-parent/modalx/src/main/java/org/wicketstuff/modalx/optional/ModalXPage.java
@@ -19,7 +19,7 @@ import org.apache.wicket.util.string.StringValueConversionException;
 import org.wicketstuff.modalx.IWicketModalVisit;
 import org.wicketstuff.modalx.ModalContentWindow;
 import org.wicketstuff.modalx.ModalMgr;
-
+import org.apache.wicket.markup.html.form.Form;
 
 // -[Class]-
 
@@ -82,10 +82,12 @@ public ModalXPage(final PageParameters iParameters)
 	
 	for (int m = 0; m < MAX_MODALS; m++)
 	{
+		Form form = new Form("wrapperForm_" + m);
+		add(form);
 		ModalContentWindow modalWindow = new ModalContentWindow(this, "modalWindow_" + m, true);
 		modalWindow.setInitialWidth(600);
 		modalWindow.setInitialHeight(400);
-		add(modalWindow);
+		form.add(modalWindow);
 		modalContentWindows[m] = modalWindow;
 	}
 }


### PR DESCRIPTION
ModalWindowS that contain forms need to be themselves wrapped in an outer form as per the intention and design of Wicket to have it work correctly in IE.
