### PR TITLE
Use only Subject to check permissions, not SecurityManager

### DIFF
--- a/jdk-1.5-parent/shiro-security/wicket-shiro/src/main/java/org/wicketstuff/shiro/annotation/AnnotationsShiroAuthorizationStrategy.java
+++ b/jdk-1.5-parent/shiro-security/wicket-shiro/src/main/java/org/wicketstuff/shiro/annotation/AnnotationsShiroAuthorizationStrategy.java
@@ -19,9 +19,7 @@ package org.wicketstuff.shiro.annotation;
 import java.lang.annotation.Annotation;
 
 import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.subject.Subject;
-import org.apache.shiro.util.ThreadContext;
 import org.apache.wicket.Component;
 import org.apache.wicket.authorization.Action;
 import org.apache.wicket.authorization.IAuthorizationStrategy;
@@ -29,100 +27,99 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wicketstuff.shiro.ShiroAction;
 
-public class AnnotationsShiroAuthorizationStrategy implements IAuthorizationStrategy
-{
-	private static final Logger LOG = LoggerFactory.getLogger(AnnotationsShiroAuthorizationStrategy.class);
+public class AnnotationsShiroAuthorizationStrategy implements IAuthorizationStrategy {
+    private static final Logger LOG = LoggerFactory
+            .getLogger(AnnotationsShiroAuthorizationStrategy.class);
 
-	/**
-	 * @param <T>
-	 * @param clazz
-	 * @return null if ok, or the Annotation that failed
-	 */
-	protected ShiroSecurityConstraint checkInvalidInstantiation(final Annotation[] annotations,
-		final ShiroAction action)
-	{
-		if (annotations == null)
-			return null;
+    /**
+     * @param <T>
+     * @param clazz
+     * @return null if ok, or the Annotation that failed
+     */
+    protected ShiroSecurityConstraint checkInvalidInstantiation(final Annotation[] annotations,
+            final ShiroAction action) {
+        if (annotations == null) {
+            return null;
+        }
 
-		for (final Annotation annotation : annotations)
-			// Check Permissions
-			if (annotation instanceof ShiroSecurityConstraint)
-			{
-				final ShiroSecurityConstraint constraint = (ShiroSecurityConstraint)annotation;
-				if (action == constraint.action())
-				{
-					final SecurityManager sm = ThreadContext.getSecurityManager();
-					final Subject subject = SecurityUtils.getSubject();
-					switch (constraint.constraint())
-					{
-						case HasRole : {
-							if (!sm.hasRole(subject.getPrincipals(), constraint.value()))
-								return constraint;
-							break;
-						}
+        for (final Annotation annotation : annotations) {
+            // Check Permissions
+            if (annotation instanceof ShiroSecurityConstraint) {
+                final ShiroSecurityConstraint constraint = (ShiroSecurityConstraint) annotation;
+                if (action == constraint.action()) {
+                    final Subject subject = SecurityUtils.getSubject();
+                    switch (constraint.constraint()) {
+                    case HasRole: {
+                        if (!subject.hasRole(constraint.value())) {
+                            return constraint;
+                        }
+                        break;
+                    }
 
-						case HasPermission : {
-							if (!sm.isPermitted(subject.getPrincipals(), constraint.value()))
-								return constraint;
-							break;
-						}
+                    case HasPermission: {
+                        if (!subject.isPermitted(constraint.value())) {
+                            return constraint;
+                        }
+                        break;
+                    }
 
-						case IsAuthenticated : {
-							if (!subject.isAuthenticated())
-								return constraint;
-							break;
-						}
+                    case IsAuthenticated: {
+                        if (!subject.isAuthenticated()) {
+                            return constraint;
+                        }
+                        break;
+                    }
 
-						case LoggedIn : {
-							if (subject.getPrincipal() == null)
-								return constraint;
-							break;
-						}
-					}
-				}
-			} // end if KiSecurityConstraint
-		return null;
-	}
+                    case LoggedIn: {
+                        if (subject.getPrincipal() == null) {
+                            return constraint;
+                        }
+                        break;
+                    }
+                    }
+                }
+            } // end if KiSecurityConstraint
+        }
+        return null;
+    }
 
-	public <T extends Component> ShiroSecurityConstraint checkInvalidInstantiation(
-		final Class<T> componentClass)
-	{
-		ShiroSecurityConstraint fail = checkInvalidInstantiation(componentClass.getAnnotations(),
-			ShiroAction.INSTANTIATE);
-		if (fail == null)
-			fail = checkInvalidInstantiation(componentClass.getPackage().getAnnotations(),
-				ShiroAction.INSTANTIATE);
-		return fail;
-	}
+    public <T extends Component> ShiroSecurityConstraint checkInvalidInstantiation(
+            final Class<T> componentClass) {
+        ShiroSecurityConstraint fail = checkInvalidInstantiation(componentClass.getAnnotations(),
+                ShiroAction.INSTANTIATE);
+        if (fail == null) {
+            fail = checkInvalidInstantiation(componentClass.getPackage().getAnnotations(),
+                    ShiroAction.INSTANTIATE);
+        }
+        return fail;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public boolean isActionAuthorized(final Component component, final Action action)
-	{
+    /**
+     * {@inheritDoc}
+     */
+    public boolean isActionAuthorized(final Component component, final Action action) {
 
-		final ShiroAction _action = action.getName().equals(Action.RENDER) ? ShiroAction.RENDER
-			: ShiroAction.ENABLE;
+        final ShiroAction _action = action.getName().equals(Action.RENDER) ? ShiroAction.RENDER
+                : ShiroAction.ENABLE;
 
-		final Class<? extends Component> clazz = component.getClass();
-		ShiroSecurityConstraint fail = checkInvalidInstantiation(clazz.getAnnotations(), _action);
-		if (fail == null)
-			fail = checkInvalidInstantiation(clazz.getPackage().getAnnotations(), _action);
-		return fail == null;
-	}
+        final Class<? extends Component> clazz = component.getClass();
+        ShiroSecurityConstraint fail = checkInvalidInstantiation(clazz.getAnnotations(), _action);
+        if (fail == null) {
+            fail = checkInvalidInstantiation(clazz.getPackage().getAnnotations(), _action);
+        }
+        return fail == null;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public <T extends Component> boolean isInstantiationAuthorized(final Class<T> componentClass)
-	{
-		final Annotation fail = checkInvalidInstantiation(componentClass);
-		if (fail != null)
-		{
-			LOG.info("Unauthorized Instantiation :: component={} reason={} subject={}",
-				new Object[] { componentClass, fail, SecurityUtils.getSubject() });
-			return false;
-		}
-		return true;
-	}
+    /**
+     * {@inheritDoc}
+     */
+    public <T extends Component> boolean isInstantiationAuthorized(final Class<T> componentClass) {
+        final Annotation fail = checkInvalidInstantiation(componentClass);
+        if (fail != null) {
+            LOG.info("Unauthorized Instantiation :: component={} reason={} subject={}",
+                    new Object[] { componentClass, fail, SecurityUtils.getSubject() });
+            return false;
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
I changed the auth strategy to only use the Subject to check permissions - asking the SecurityManager itself is not necessary.

By using only the Subject testing is simplified, because only the subject needs to be mocked.

This is the fix for the 1.4 branch.
