### PR TITLE
1.5 - Use only Subject to check permissions, not SecurityManager

### DIFF
--- a/jdk-1.5-parent/shiro-security/wicket-shiro/src/main/java/org/wicketstuff/shiro/annotation/AnnotationsShiroAuthorizationStrategy.java
+++ b/jdk-1.5-parent/shiro-security/wicket-shiro/src/main/java/org/wicketstuff/shiro/annotation/AnnotationsShiroAuthorizationStrategy.java
@@ -19,9 +19,7 @@ package org.wicketstuff.shiro.annotation;
 import java.lang.annotation.Annotation;
 
 import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.mgt.SecurityManager;
 import org.apache.shiro.subject.Subject;
-import org.apache.shiro.util.ThreadContext;
 import org.apache.wicket.Component;
 import org.apache.wicket.authorization.Action;
 import org.apache.wicket.authorization.IAuthorizationStrategy;
@@ -43,49 +41,56 @@ public class AnnotationsShiroAuthorizationStrategy implements IAuthorizationStra
 		final ShiroAction action)
 	{
 		if (annotations == null)
+		{
 			return null;
+		}
 
 		for (final Annotation annotation : annotations)
+		{
 			// Check Permissions
 			if (annotation instanceof ShiroSecurityConstraint)
 			{
 				final ShiroSecurityConstraint constraint = (ShiroSecurityConstraint)annotation;
 				if (action == constraint.action())
 				{
-					final SecurityManager sm = ThreadContext.getSecurityManager();
 					final Subject subject = SecurityUtils.getSubject();
 					switch (constraint.constraint())
 					{
-						case HasRole :
-						{
-							if (!sm.hasRole(subject.getPrincipals(), constraint.value()))
+						case HasRole : {
+							if (!subject.hasRole(constraint.value()))
+							{
 								return constraint;
+							}
 							break;
 						}
 
-						case HasPermission :
-						{
-							if (!sm.isPermitted(subject.getPrincipals(), constraint.value()))
+						case HasPermission : {
+							if (!subject.isPermitted(constraint.value()))
+							{
 								return constraint;
+							}
 							break;
 						}
 
-						case IsAuthenticated :
-						{
+						case IsAuthenticated : {
 							if (!subject.isAuthenticated())
+							{
 								return constraint;
+							}
 							break;
 						}
 
-						case LoggedIn :
-						{
+						case LoggedIn : {
 							if (subject.getPrincipal() == null)
+							{
 								return constraint;
+							}
 							break;
 						}
 					}
 				}
 			} // end if KiSecurityConstraint
+		}
 		return null;
 	}
 
@@ -95,8 +100,10 @@ public class AnnotationsShiroAuthorizationStrategy implements IAuthorizationStra
 		ShiroSecurityConstraint fail = checkInvalidInstantiation(componentClass.getAnnotations(),
 			ShiroAction.INSTANTIATE);
 		if (fail == null)
+		{
 			fail = checkInvalidInstantiation(componentClass.getPackage().getAnnotations(),
 				ShiroAction.INSTANTIATE);
+		}
 		return fail;
 	}
 
@@ -112,7 +119,9 @@ public class AnnotationsShiroAuthorizationStrategy implements IAuthorizationStra
 		final Class<? extends Component> clazz = component.getClass();
 		ShiroSecurityConstraint fail = checkInvalidInstantiation(clazz.getAnnotations(), _action);
 		if (fail == null)
+		{
 			fail = checkInvalidInstantiation(clazz.getPackage().getAnnotations(), _action);
+		}
 		return fail == null;
 	}
 


### PR DESCRIPTION
I changed the auth strategy to only use the Subject to check permissions - asking the SecurityManager itself is not necessary.

By using only the Subject testing is simplified, because only the subject needs to be mocked.

This is the fix for the 1.5 branch.
