### PR TITLE
please consider this patch to fix gh-85

### DIFF
--- a/jdk-1.6-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/Chart.java
+++ b/jdk-1.6-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/Chart.java
@@ -225,7 +225,7 @@ public class Chart extends WebComponent implements Serializable
 			return null;
 		}
 
-		StringBuilder back = new StringBuilder(barWidth);
+		StringBuilder back = new StringBuilder("" + barWidth);
 
 		if (groupSpacing >= 0)
 		{


### PR DESCRIPTION
...his allows barWidth to be rendered properly.

Note that Google's API now supports a 3rd param here, for space_between_bars:

```
chbh=
  <bar_width_or_scale>,<space_between_bars>,<space_between_groups>
```

(see http://code.google.com/apis/chart/image/docs/gallery/bar_charts.html#chbh)

I don't see how wicketstuff could support this without breaking existing code, as we'd have to modify IChartProvider to have a new method "getBarSpacing" or somesuch.
