### PR TITLE
fixed issue #89 (DataGrid selection indication is broken)

### DIFF
--- a/jdk-1.5-parent/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/datagrid/DataGridBody.java
+++ b/jdk-1.5-parent/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/datagrid/DataGridBody.java
@@ -231,7 +231,7 @@ public abstract class DataGridBody<D extends IDataSource<T>, T> extends Panel
 
 				klass = klass + " imxt-want-prelight imxt-grid-row";
 
-				if (isItemSelected(getDefaultItemModel()))
+				if (isItemSelected((IModel<T>)getDefaultModel()))
 				{
 					klass = klass + " imxt-selected";
 				}
@@ -262,8 +262,4 @@ public abstract class DataGridBody<D extends IDataSource<T>, T> extends Panel
     }
 	}
   
-	protected IModel<T> getDefaultItemModel()
-	{
-		return (IModel<T>)getDefaultModel();
-	}
 }


### PR DESCRIPTION
With this fix the datagrid marks the selected rows again (with blue background color).
Going by the code the same problem should occur in 1.6 / master branch.
