### PR TITLE
Patch to fix the problem with removed "org" from "org.cometd" to load th...

### DIFF
--- a/jdk-1.5-parent/push-parent-jdk-1.5/push-core/pom.xml
+++ b/jdk-1.5-parent/push-parent-jdk-1.5/push-core/pom.xml
@@ -9,9 +9,41 @@
 	</parent>
 
 	<artifactId>push-core</artifactId>
-	<packaging>jar</packaging>
+	<packaging>bundle</packaging>
 
 	<name>Wicketstuff Push - Core</name>
 	<description>An integration project for server side pushing in Wicket</description>
 
+	<properties>
+		<wicketstuff.osgi.import.package>org.apache.wicket.*; version="[${project.version},${project.version}]", *</wicketstuff.osgi.import.package>
+		<wicketstuff.osgi.private.package />
+		<wicketstuff.osgi.export.package>*; version="${project.version}"</wicketstuff.osgi.export.package>
+		<wicketstuff.osgi.embed.dependency />
+	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.3.4</version>
+				<extensions>true</extensions>
+				<configuration>
+					<obrRepository>NONE</obrRepository>
+					<excludeDependencies>true</excludeDependencies>
+					<instructions>
+						<Bundle-Name>${project.artifactId}-${project.version}</Bundle-Name>
+						<Bundle-SymbolicName>${project.artifactId}-${project.version}</Bundle-SymbolicName>
+						<Bundle-Description>${project.description}</Bundle-Description>
+						<Bundle-Version>${project.version}</Bundle-Version>
+						<Export-Package>${wicketstuff.osgi.export.package}</Export-Package>
+						<Import-Package>${wicketstuff.osgi.import.package}</Import-Package>
+						<Private-Package>${wicketstuff.osgi.private.package}</Private-Package>
+						<Embed-Dependency>${wicketstuff.osgi.embed.dependency}</Embed-Dependency>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+	
 </project>

--- a/jdk-1.6-parent/push-parent-jdk-1.6/push-cometd/pom.xml
+++ b/jdk-1.6-parent/push-parent-jdk-1.6/push-cometd/pom.xml
@@ -9,11 +9,18 @@
 	</parent>
 
 	<artifactId>push-cometd</artifactId>
-	<packaging>jar</packaging>
+	<packaging>bundle</packaging>
 
 	<name>Wicketstuff Push - CometD</name>
 	<description>CometD (bayeux) implementation of Wicketstuff Push</description>
 
+	<properties>
+		<wicketstuff.osgi.import.package>org.apache.wicket.*; version="[${project.version},${project.version}]", org.wicketstuff.push.*; version="[${project.version},${project.version}]", *</wicketstuff.osgi.import.package>
+		<wicketstuff.osgi.private.package />
+		<wicketstuff.osgi.export.package>*; version="${project.version}"</wicketstuff.osgi.export.package>
+		<wicketstuff.osgi.embed.dependency />
+	</properties>
+	
 	<dependencies>
 
 		<dependency>
@@ -63,7 +70,7 @@
 									<version>${cometd.version}</version>
 									<type>war</type>
 									<overWrite>false</overWrite>
-									<outputDirectory>${project.build.outputDirectory}/org/wicketstuff/push/cometd</outputDirectory>
+									<outputDirectory>${project.build.directory}/dependency</outputDirectory>
 								</artifactItem>
 							</artifactItems>
 							<includes>**/*.js</includes>
@@ -73,6 +80,51 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>2.5</version>
+				<executions>
+					<execution>
+						<id>copy-resources</id>
+						<!-- here the phase you need -->
+						<phase>process-resources</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<resources>
+								<resource>
+									<directory>${project.build.directory}/dependency/org</directory>
+								</resource>
+							</resources>
+							<outputDirectory>${project.build.outputDirectory}/org/wicketstuff/push/cometd/js</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.3.4</version>
+				<extensions>true</extensions>
+				<configuration>
+					<obrRepository>NONE</obrRepository>
+					<excludeDependencies>true</excludeDependencies>
+					<instructions>
+						<Bundle-Name>${project.artifactId}-${project.version}</Bundle-Name>
+						<Bundle-SymbolicName>${project.artifactId}-${project.version}</Bundle-SymbolicName>
+						<Bundle-Description>${project.description}</Bundle-Description>
+						<Bundle-Version>${project.version}</Bundle-Version>
+						<Export-Package>${wicketstuff.osgi.export.package}</Export-Package>
+						<Import-Package>${wicketstuff.osgi.import.package}</Import-Package>
+						<Private-Package>${wicketstuff.osgi.private.package}</Private-Package>
+						<Embed-Dependency>${wicketstuff.osgi.embed.dependency}</Embed-Dependency>
+					</instructions>
+				</configuration>
+			</plugin>
+			
 		</plugins>
 	</build>
 </project>

--- a/jdk-1.6-parent/push-parent-jdk-1.6/push-cometd/src/main/java/org/wicketstuff/push/cometd/CometdPushBehavior.java
+++ b/jdk-1.6-parent/push-parent-jdk-1.6/push-cometd/src/main/java/org/wicketstuff/push/cometd/CometdPushBehavior.java
@@ -64,15 +64,15 @@ public class CometdPushBehavior extends AbstractDefaultAjaxBehavior
 	private static final String DEFAULT_COMETD_PATH = guessCometdServletPath();
 
 	private static final ResourceReference COMETD = new CompressedResourceReference(
-		CometdPushBehavior.class, "org/cometd.js");
+		CometdPushBehavior.class, "js/cometd.js");
 	private static final ResourceReference COMETD_ACK = new CompressedResourceReference(
-		CometdPushBehavior.class, "org/cometd/AckExtension.js");
+		CometdPushBehavior.class, "js/cometd/AckExtension.js");
 	private static final ResourceReference COMETD_RELOAD = new CompressedResourceReference(
-		CometdPushBehavior.class, "org/cometd/ReloadExtension.js");
+		CometdPushBehavior.class, "js/cometd/ReloadExtension.js");
 	private static final ResourceReference COMETD_TIMESTAMP = new CompressedResourceReference(
-		CometdPushBehavior.class, "org/cometd/TimeStampExtension.js");
+		CometdPushBehavior.class, "js/cometd/TimeStampExtension.js");
 	private static final ResourceReference COMETD_TIMESYNC = new CompressedResourceReference(
-		CometdPushBehavior.class, "org/cometd/TimeSyncExtension.js");
+		CometdPushBehavior.class, "js/cometd/TimeSyncExtension.js");
 
 	private static final PackagedTextTemplate TEMPLATE_INIT = new PackagedTextTemplate(
 		CometdPushBehavior.class, "CometdPushInit.js");


### PR DESCRIPTION
...e javascript from cometd. This patch just changes the packagename from "org.cometd" to "js.cometd" to work with wicket-1.4.20.

Signed-off-by: Andreas Kuhtz andreas.kuhtz@gmail.com
