### PR TITLE
removed a duplicate function declaration which caused a javascript error

### DIFF
--- a/jdk-1.6-parent/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/common/AbstractGrid.java
+++ b/jdk-1.6-parent/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/common/AbstractGrid.java
@@ -507,9 +507,9 @@ public abstract class AbstractGrid<M, I> extends Panel
 		sb.append("];\n");
 
 		// method that calls the proper listener when column state is changed
-		sb.append("var submitStateCallback = function(columnState) { ");
+		sb.append("var submitStateCallback = ");
 		sb.append(submitColumnStateBehavior.getCallbackScript());
-		sb.append(" }\n");
+		sb.append("\n");
 
 		// initialization
 		sb.append("InMethod.XTableManager.instance.register(\"" + getMarkupId() +


### PR DESCRIPTION
The current version produced javascript code like the following:
var submitStateCallback = function(columnState) { function (columnState) {
var attrs = ...
