### PR TITLE
Core 1.5.x

### DIFF
--- a/jdk-1.5-parent/prototype/src/test/java/org/wicketstuff/prototype/PrototypeHeaderContributorTest.java
+++ b/jdk-1.5-parent/prototype/src/test/java/org/wicketstuff/prototype/PrototypeHeaderContributorTest.java
@@ -58,7 +58,7 @@ public class PrototypeHeaderContributorTest extends TestCase
 		new PrototypeHeaderContributor().renderHead(null, mockResponse);
 
 		assertEquals(
-			"<script type=\"text/javascript\" src=\"wicket/resource/org.wicketstuff.prototype.PrototypeResourceReference/prototype.js\"></script>\n",
+			"<script type=\"text/javascript\" src=\"./wicket/resource/org.wicketstuff.prototype.PrototypeResourceReference/prototype.js\"></script>\n",
 			builder.toString());
 	}
 }


### PR DESCRIPTION
Fixed a test that was failing due to new URL format ( ./.... ) in latest wicket 1.5 snapshot
