### PR TITLE
Fixed compilation issue and a NPE in GMap2

### DIFF
--- a/jdk-1.6-parent/gmap2-parent/gmap2/src/main/java/wicket/contrib/gmap/api/GClientGeocoder.java
+++ b/jdk-1.6-parent/gmap2-parent/gmap2/src/main/java/wicket/contrib/gmap/api/GClientGeocoder.java
@@ -3,6 +3,7 @@ package wicket.contrib.gmap.api;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.CallbackParameter;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.request.IRequestParameters;
@@ -62,7 +63,7 @@ public abstract class GClientGeocoder extends AjaxEventBehavior
 	@Override
 	public CharSequence getCallbackScript()
 	{
-		return "Wicket.geocoder.getLatLng('" + getCallbackFunction("status", "address", "point") + "', '" +
+		return "Wicket.geocoder.getLatLng('" + getCallbackFunction(CallbackParameter.explicit("status"), CallbackParameter.explicit("address"), CallbackParameter.explicit("point")) + "', '" +
 			addressField.getMarkupId() + "');" + "return false;";
 	}
 }

--- a/jdk-1.6-parent/gmap2-parent/gmap2/src/main/java/wicket/contrib/gmap/api/GOverlay.java
+++ b/jdk-1.6-parent/gmap2-parent/gmap2/src/main/java/wicket/contrib/gmap/api/GOverlay.java
@@ -124,7 +124,7 @@ public abstract class GOverlay implements Serializable
 		// TODO
 		// && getParent().findPage() != null)
 		AjaxRequestTarget target = RequestCycle.get().find(AjaxRequestTarget.class);
-		if (target != null)
+		if (target != null && getParent() != null)
 		{
 			target.appendJavaScript(event.getJSadd(this));
 		}


### PR DESCRIPTION
- wicket.contrib.gmap.api.GClientGeocoder#getCallbackScript could not be compiled because getCallbackFunction didn't accept strings as parameters.
- In GOverlay a NullPointerException occured when using the DragEndListener.
