### PR TITLE
InMethod Grid: NPE when redirected from ajax

### DIFF
--- a/jdk-1.5-parent/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/common/AbstractGrid.java
+++ b/jdk-1.5-parent/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/common/AbstractGrid.java
@@ -115,20 +115,7 @@ public abstract class AbstractGrid<M, I> extends Panel
 				// since javascript can be rendered at the tail
 				// of HTML document, do not initialize data grid
 				// component until "DOM ready" event.
-				if (!getWebRequest().isAjax())
-				{
-					response.renderOnDomReadyJavaScript(getInitializationJavascript());
-				}
-			}
-
-			@Override
-			public void afterRender(Component component)
-			{
-				super.afterRender(component);
-				if (getWebRequest().isAjax())
-				{
-					AjaxRequestTarget.get().appendJavaScript(getInitializationJavascript());
-				}
+				response.renderOnDomReadyJavaScript(getInitializationJavascript());
 			}
 		});
 


### PR DESCRIPTION
NPE in com.inmethod.grid.common.AbstractGrid (line 130, constructor -> Behavior#afterRender)... 

```
if (getWebRequest().isAjax()) { 
    AjaxRequestTarget.get().appendJavaScript(getInitializationJavascript()); // -> NPE
} 
```

...because isAjax() is true, but AjaxRequestTarget.get() is null. 

You can reproduce this simply by a AjaxLink with:

```
public void onClick(AjaxRequestTarget target) {
    setResponsePage(new PageContainingAInMethodGrid());
}
```

See also: http://apache-wicket.1842946.n4.nabble.com/NPE-with-setResponsePage-using-Page-from-PageManager-td4650186.html#a4650188
