### PR TITLE
normal links doesn't work in columns

### DIFF
--- a/jdk-1.6-parent/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/common/AbstractGrid.java
+++ b/jdk-1.6-parent/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/common/AbstractGrid.java
@@ -838,6 +838,7 @@ public abstract class AbstractGrid<M, I, S> extends Panel
 				CharSequence precondition = "return InMethod.XTable.canSelectRow(attrs.event);";
 				AjaxCallListener ajaxCallListener = new AjaxCallListener();
 				ajaxCallListener.onPrecondition(precondition);
+				attributes.setAllowDefault(true);
 				attributes.getAjaxCallListeners().add(ajaxCallListener);
 			}
       


### PR DESCRIPTION
Because of JS preventDefault it is not possible to click on inmethod grid row which contains some link (<a href="...">something</a>). 
