### PR TITLE
[wicketstuff-security-wasp] Fixed compilation error.

### DIFF
--- a/jdk-1.6-parent/wicket-security-parent/wasp-parent/wasp/src/main/java/org/wicketstuff/security/log/AuthorizationMessageSource.java
+++ b/jdk-1.6-parent/wicket-security-parent/wasp-parent/wasp/src/main/java/org/wicketstuff/security/log/AuthorizationMessageSource.java
@@ -66,9 +66,10 @@ public class AuthorizationMessageSource implements IAuthorizationMessageSource
 	}
 
 	/**
-	 * @see org.apache.wicket.validation.IErrorMessageSource#getMessage(java.lang.String)
+	 * @see org.apache.wicket.validation.IErrorMessageSource#getMessage(java.lang.String, java.util.Map) 
 	 */
-	public final String getMessage(String key)
+        @Override
+	public final String getMessage(String key, Map<String, Object> vars)
 	{
 		Localizer localizer = Application.get().getResourceSettings().getLocalizer();
 		// Note: It is important that the default value of "" is provided
@@ -76,28 +77,23 @@ public class AuthorizationMessageSource implements IAuthorizationMessageSource
 		// return a default string like "[Warning: String ..."
 		String message = localizer.getString(key, getComponent(), "");
 		if (Strings.isEmpty(message))
+                {			
 			return null;
-		return message;
+                }
+		else
+		{
+		    return new MapVariableInterpolator(message, mergeVariables(vars), Application.get()
+			.getResourceSettings()
+			.getThrowExceptionOnMissingResource()).toString();
+		}
 	}
-
+	
 	/**
 	 * @see org.wicketstuff.security.log.IAuthorizationMessageSource#getComponent()
 	 */
 	public final Component getComponent()
 	{
 		return component;
-	}
-
-	/**
-	 * @see org.apache.wicket.validation.IErrorMessageSource#substitute(java.lang.String,
-	 *      java.util.Map)
-	 */
-	public final String substitute(String string, Map<String, Object> vars)
-		throws IllegalStateException
-	{
-		return new MapVariableInterpolator(string, mergeVariables(vars), Application.get()
-			.getResourceSettings()
-			.getThrowExceptionOnMissingResource()).toString();
 	}
 
 	/**

--- a/jdk-1.6-parent/wicket-security-parent/wasp-parent/wasp/src/main/java/org/wicketstuff/security/strategies/WaspAuthorizationStrategy.java
+++ b/jdk-1.6-parent/wicket-security-parent/wasp-parent/wasp/src/main/java/org/wicketstuff/security/strategies/WaspAuthorizationStrategy.java
@@ -275,9 +275,9 @@ public abstract class WaspAuthorizationStrategy implements IAuthorizationStrateg
 	protected void logMessage(String key, Map<String, Object> variables,
 		IAuthorizationMessageSource message)
 	{
-		String msg = message.getMessage(key);
+		String msg = message.getMessage(key, variables);
 		if (!Strings.isEmpty(msg))
-			log.debug(message.substitute(msg, variables));
+                    log.debug(msg);
 	}
 
 	/**


### PR DESCRIPTION
(In Wicket 6 IErrorMessageSource#substitute(Map<String,Object>) was merged into IErrorMessageSource#getMessage(String, Map<String,Object>))
