### PR TITLE
GlobalJndiNamingStrategy calculates name according to spec

### DIFF
--- a/jdk-1.6-parent/javaee-inject-parent/javaee-inject/pom.xml
+++ b/jdk-1.6-parent/javaee-inject-parent/javaee-inject/pom.xml
@@ -29,5 +29,16 @@
             <version>6.0</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+            <version>1.4</version>
+        </dependency>
     </dependencies>
 </project>

--- a/jdk-1.6-parent/javaee-inject-parent/javaee-inject/src/main/java/org/wicketstuff/javaee/naming/global/GlobalJndiNamingStrategy.java
+++ b/jdk-1.6-parent/javaee-inject-parent/javaee-inject/src/main/java/org/wicketstuff/javaee/naming/global/GlobalJndiNamingStrategy.java
@@ -87,6 +87,9 @@ public class GlobalJndiNamingStrategy implements IJndiNamingStrategy
 	@Override
 	public String calculateName(String ejbName, Class<?> ejbType)
 	{
-		return baseName + (ejbName == null ? ejbType.getName() : ejbName);
+        if (ejbName == null) {
+            return baseName + ejbType.getName();
+        }
+        return baseName + ejbName + "!" + ejbType.getName();
 	}
 }

--- a/jdk-1.6-parent/javaee-inject-parent/javaee-inject/src/test/java/org/wicketstuff/javaee/naming/global/GlobalJndiNamingStrategyTest.java
+++ b/jdk-1.6-parent/javaee-inject-parent/javaee-inject/src/test/java/org/wicketstuff/javaee/naming/global/GlobalJndiNamingStrategyTest.java
@@ -1,0 +1,30 @@
+package org.wicketstuff.javaee.naming.global;
+
+
+import org.testng.annotations.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+
+/**
+ * The container has to register one JNDI global entry for every local and remote business interface implemented by the EJB and its no-interface view.
+ * <pre>
+ *      java:global[/<app-name>]/<module-name>/<bean-name>[!<interface-FQN>]
+ * </pre>
+ *
+ * If an EJB implements only one business interface or only has a no-interface view, the container is also required to register such a view with the following JNDI name:
+ * <pre>
+ *      java:global[/<app-name>]/<module-name>/<bean-name>
+ * </pre>
+ */
+public class GlobalJndiNamingStrategyTest {
+
+    private GlobalJndiNamingStrategy namingStrategy = new GlobalJndiNamingStrategy("appname", "modulename");
+
+    @Test
+    public void nameAccordingToSpecification() {
+        assertThat(namingStrategy.calculateName(null, String.class)).isEqualTo("java:global/appname/modulename/java.lang.String");
+        assertThat(namingStrategy.calculateName("beanname", String.class)).isEqualTo("java:global/appname/modulename/beanname!java.lang.String");
+    }
+
+}


### PR DESCRIPTION
The GlobalJndiNamingStrategy is not working for EJBs that implement multiple interfaces.

http://thegreyblog.blogspot.se/2010/09/ejb-31-global-jndi-access.html
