### PR TITLE
Fixed misplacement of completion list if the objectautocomplete is used in a scrollable modal window

### DIFF
--- a/jdk-1.6-parent/objectautocomplete-parent/objectautocomplete/src/main/java/org/wicketstuff/objectautocomplete/wicketstuff-dropdown-list.js
+++ b/jdk-1.6-parent/objectautocomplete-parent/objectautocomplete/src/main/java/org/wicketstuff/objectautocomplete/wicketstuff-dropdown-list.js
@@ -361,13 +361,16 @@ Wicketstuff.DropDownList = function(elementId,updateChoicesFunc,updateValueFunc,
   }
 
   function getPosition(obj) {
-    var leftPosition = 0;
-    var topPosition = 0;
-    do {
+    var leftPosition = obj.offsetLeft || 0;
+    var topPosition = obj.offsetTop || 0;
+    obj = obj.offsetParent;
+    while (obj && obj != document.documentElement && obj != document.body) {
       topPosition += obj.offsetTop || 0;
+      topPosition -= obj.scrollTop || 0;
       leftPosition += obj.offsetLeft || 0;
+      leftPosition -= obj.scrollLeft || 0;
       obj = obj.offsetParent;
-    } while (obj);
+    }
     return [leftPosition,topPosition];
   }
 


### PR DESCRIPTION
Code blatantly stolen from wicket-autocomplete.js (Johan Compagner - https://github.com/apache/wicket/commit/fabf8f641d41d968ab7f23adfdaf0c26f5eae62e).

It seems there is some functional overlap with the regular wicket-autocomplete that should be taken advantage of, however this is maybe not straightforward, especially on the javascript side.
