### PR TITLE
lat/lon is always in US locale, using valueOf

### DIFF
--- a/jdk-1.6-parent/gmap3-parent/gmap3/src/main/java/org/wicketstuff/gmap/event/ClickListener.java
+++ b/jdk-1.6-parent/gmap3-parent/gmap3/src/main/java/org/wicketstuff/gmap/event/ClickListener.java
@@ -44,8 +44,8 @@ public abstract class ClickListener extends GEventListenerBehavior
         Request request = RequestCycle.get().getRequest();
         GLatLng latLng = null;
 
-        Double lat = request.getRequestParameters().getParameterValue("lat").toDouble();
-        Double lng = request.getRequestParameters().getParameterValue("lng").toDouble();
+        Double lat = Double.valueOf(request.getRequestParameters().getParameterValue("lat").toString());
+        Double lng = Double.valueOf(request.getRequestParameters().getParameterValue("lng").toString());
         latLng = new GLatLng(lat, lng);
 
         onClick(target, latLng);


### PR DESCRIPTION
StringValue.toDouble uses NumberFormat to parse parameter,
but lat/lng is always in US locale (e.g. 50.123456) 
Changed to use simple Double.valueOf
