### PR TITLE
Fix for ImageUploadPlugin and IE

### DIFF
--- a/jdk-1.6-parent/tinymce-parent/tinymce/src/main/java/wicket/contrib/tinymce/image/imageUpload.js
+++ b/jdk-1.6-parent/tinymce-parent/tinymce/src/main/java/wicket/contrib/tinymce/image/imageUpload.js
@@ -11,6 +11,6 @@ var putImage = function(image) {
 
 var saveBookmark = function() {
     if (isIE) {
-        __lastPositionBookMark = activeEditor.selection.getBookmark();
+        __lastPositionBookMark = tinyMCE.activeEditor.selection.getBookmark();
     }
 };


### PR DESCRIPTION
Method saveBookmark from imageUpload.js causes a nagging error with AJAX because it uses activeEditor without accessing it through variable tinyMCE. 
Tested with IE 7, 8 and 9
