### PR TITLE
Fix notLoggedIn redirect check.

### DIFF
--- a/jdk-1.6-parent/shiro-security/wicket-shiro/src/main/java/org/wicketstuff/shiro/authz/ShiroUnauthorizedComponentListener.java
+++ b/jdk-1.6-parent/shiro-security/wicket-shiro/src/main/java/org/wicketstuff/shiro/authz/ShiroUnauthorizedComponentListener.java
@@ -84,7 +84,7 @@ public class ShiroUnauthorizedComponentListener implements
 	public void onUnauthorizedInstantiation(final Component component)
 	{
 		final Subject subject = SecurityUtils.getSubject();
-		final boolean notLoggedIn = subject.getPrincipal() == null;
+		final boolean notLoggedIn = !subject.isAuthenticated();
 		final Class<? extends Page> page = notLoggedIn ? loginPage : unauthorizedPage;
 
 		if (annotationStrategy != null)


### PR DESCRIPTION
If Shiro's remember me services are turned on then a subject can have a principal without being logged in.  When this happens ShiroUnauthorizedComponentListener redirects to the unauthorized page instead of to the login page.  This pull request changes the notLoggedIn check to see whether the subject isAuthenticated() instead of whether it has a non-null principal, allowing it to redirect to the login page.
