### PR TITLE
Introduce a separate sort property type parameter

### DIFF
--- a/jdk-1.6-parent/wicketstuff-lazymodel/src/main/java/org/wicketstuff/lazymodel/LazyColumn.java
+++ b/jdk-1.6-parent/wicketstuff-lazymodel/src/main/java/org/wicketstuff/lazymodel/LazyColumn.java
@@ -36,6 +36,8 @@ import org.wicketstuff.lazymodel.LazyModel.Evaluation;
  * 
  * @param T
  *            row object type
+ * @param S
+ *            sort property type
  * @param R
  *            cell object type
  * 
@@ -43,39 +45,39 @@ import org.wicketstuff.lazymodel.LazyModel.Evaluation;
  * 
  * @author svenmeier
  */
-public class LazyColumn<T, R> extends AbstractColumn<T, LazyModel<R>> implements
-		IExportableColumn<T, LazyModel<R>, R> {
+public class LazyColumn<T, S, R> extends AbstractColumn<T, S> implements
+		IExportableColumn<T, S, R> {
 
 	private final LazyModel<R> model;
 
-	/**
-	 * Create a non-sortable column.
-	 * 
+        /**
+         * Creates a new non-sortable column.
+         *
 	 * @param displayModel
 	 *            model for the header
 	 * @param evaluationResult
 	 *            result of an evaluation
-	 */
-	public LazyColumn(IModel<String> displayModel, R evaluationResult) {
-		this(displayModel, evaluationResult, false);
-	}
+         */
+        public LazyColumn(IModel<String> displayModel, R evaluationResult)
+        {
+            this(displayModel, evaluationResult, null);
+        }
 
-	/**
-	 * Create a column.
-	 * 
+        /**
+         * Creates a new column. If the {@code sortProperty} is not {@code null}, then the column will be sortable.
+         *
 	 * @param displayModel
 	 *            model for the header
 	 * @param evaluationResult
 	 *            result of an evaluation
-	 * @param sortable
-	 *            is this column sortable
-	 */
-	public LazyColumn(IModel<String> displayModel, R evaluationResult,
-			boolean sortable) {
-		super(displayModel, sortable ? model(evaluationResult) : null);
-
-		this.model = model(evaluationResult);
-	}
+         * @param sortProperty
+         *            sort property to use when sorting by this column
+         */
+        public LazyColumn(IModel<String> displayModel, R evaluationResult, S sortProperty)
+        {
+            super(displayModel, sortProperty);
+            this.model = model(evaluationResult);
+        }
 
 	@Override
 	public void detach() {

--- a/jdk-1.6-parent/wicketstuff-lazymodel/src/test/java/org/wicketstuff/lazymodel/LazyColumnTest.java
+++ b/jdk-1.6-parent/wicketstuff-lazymodel/src/test/java/org/wicketstuff/lazymodel/LazyColumnTest.java
@@ -34,7 +34,7 @@ public class LazyColumnTest {
 
 	@Test
 	public void bindToRow() {
-		LazyColumn<A, B> column = new LazyColumn<A, B>(
+		LazyColumn<A, Void, B> column = new LazyColumn<A, Void, B>(
 				Model.of("test"), from(A.class).getB());
 
 		A a1 = new A();


### PR DESCRIPTION
We cannot assume that the sort type will be the same as the cell type. The data provider is responsible for sorting according to the one sort type it can sort with. If the sort type is the same as the cell type, then we cannot mix columns with different cell types using the same data provider.
