### PR TITLE
Allow multiple ShiroSecurityConstraints on a single page

### DIFF
--- a/jdk-1.6-parent/shiro-security/wicket-shiro/src/main/java/org/wicketstuff/shiro/annotation/ShiroSecurityConstraints.java
+++ b/jdk-1.6-parent/shiro-security/wicket-shiro/src/main/java/org/wicketstuff/shiro/annotation/ShiroSecurityConstraints.java
@@ -1,0 +1,14 @@
+package org.wicketstuff.shiro.annotation;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface ShiroSecurityConstraints {
+
+	ShiroSecurityConstraint[] value();
+
+}
+


### PR DESCRIPTION
Added ShiroSecurityConstraints annotation to allow multiple ShiroSecurityConstraint annotations on a single page. 

For example:
If some edit page is only allowed in case the user is Authenticated (remembered users will have to login again) 

@ShiroSecurityConstraints({
        @ShiroSecurityConstraint(constraint = ShiroConstraint.HasPermission, value = "editPermission"),
        @ShiroSecurityConstraint(constraint = ShiroConstraint.IsAuthenticated)}
)
