### PR TITLE
Making LazyModel work when created from a class, then bound to a non-IObjectClassAwareModel.

### DIFF
--- a/jdk-1.6-parent/wicketstuff-lazymodel/src/main/java/org/wicketstuff/lazymodel/LazyModel.java
+++ b/jdk-1.6-parent/wicketstuff-lazymodel/src/main/java/org/wicketstuff/lazymodel/LazyModel.java
@@ -96,13 +96,19 @@ public class LazyModel<T> implements IModel<T>, IObjectClassAwareModel<T>,
 	protected final Object target;
 
 	/**
+	 * The target type.
+	 */
+	protected final Type targetType;
+
+	/**
 	 * Each invoked method's identifier followed by its arguments.
 	 */
 	protected final Object stack;
 
-	LazyModel(Object target, Object stack) {
+	LazyModel(Object target, Object stack, Type targetType) {
 		this.target = target;
 		this.stack = stack;
+		this.targetType = targetType;
 	}
 
 	/**
@@ -251,7 +257,7 @@ public class LazyModel<T> implements IModel<T>, IObjectClassAwareModel<T>,
 	 * @return bound model
 	 */
 	public LazyModel<T> bind(Object target) {
-		return new LazyModel<T>(target, stack);
+		return new LazyModel<T>(target, stack, targetType);
 	}
 
 	/**
@@ -306,7 +312,9 @@ public class LazyModel<T> implements IModel<T>, IObjectClassAwareModel<T>,
 	private Type getTargetType() {
 		Type type;
 
-		if (target instanceof IObjectTypeAwareModel) {
+		if (targetType != null) {
+			type = targetType;
+		} else if (target instanceof IObjectTypeAwareModel) {
 			type = ((IObjectTypeAwareModel<?>) target).getObjectType();
 		} else if (target instanceof IObjectClassAwareModel) {
 			type = ((IObjectClassAwareModel<?>) target).getObjectClass();
@@ -493,10 +501,16 @@ public class LazyModel<T> implements IModel<T>, IObjectClassAwareModel<T>,
 		 */
 		private Type type;
 
+		/**
+		 * The root target type.
+		 */
+		private final Type targetType;
+
 		protected Evaluation(Object target) {
 			this.target = target;
 
 			type = target.getClass();
+			targetType = type;
 		}
 
 		protected Evaluation(IModel target) {
@@ -518,12 +532,14 @@ public class LazyModel<T> implements IModel<T>, IObjectClassAwareModel<T>,
 					throw new WicketRuntimeException(ex);
 				}
 			}
+			targetType = type;
 		}
 
 		protected Evaluation(Type type) {
 			this.target = null;
 
 			this.type = type;
+			this.targetType = type;
 		}
 
 		public Object getTarget() {
@@ -578,7 +594,7 @@ public class LazyModel<T> implements IModel<T>, IObjectClassAwareModel<T>,
 					if (evaluation != null) {
 						lastNonProxyableEvaluation.remove();
 						stack.add(new LazyModel(evaluation.getTarget(),
-								evaluation.getStack()));
+								evaluation.getStack(), targetType));
 						continue;
 					}
 				}
@@ -589,7 +605,7 @@ public class LazyModel<T> implements IModel<T>, IObjectClassAwareModel<T>,
 							.getCallback(param);
 					if (evaluation != null) {
 						stack.add(new LazyModel(evaluation.getTarget(),
-								evaluation.getStack()));
+								evaluation.getStack(), targetType));
 						continue;
 					}
 				}
@@ -735,7 +751,8 @@ public class LazyModel<T> implements IModel<T>, IObjectClassAwareModel<T>,
 	public static <R> LazyModel<R> model(R result) {
 		Evaluation evaluation = evaluation(result);
 		
-		return new LazyModel<R>(evaluation.getTarget(), evaluation.getStack());
+		return new LazyModel<R>(evaluation.getTarget(), evaluation.getStack(),
+		    evaluation.targetType);
 	}
 
 	/**

--- a/jdk-1.6-parent/wicketstuff-lazymodel/src/test/java/org/wicketstuff/lazymodel/LazyModelTest.java
+++ b/jdk-1.6-parent/wicketstuff-lazymodel/src/test/java/org/wicketstuff/lazymodel/LazyModelTest.java
@@ -33,6 +33,7 @@ import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.model.AbstractReadOnlyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.IObjectClassAwareModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.junit.Test;
 import org.wicketstuff.lazymodel.reflect.Generics;
@@ -601,19 +602,16 @@ public class LazyModelTest {
 	 * A {@link IObjectClassAwareModel} doesn't provide generic information,
 	 * thus the type of the model result is {@code List<Object>} only.
 	 */
-	@Test
+	@Test(expected=ClassCastException.class)
 	public void getEntryFromGenericListInObjectClassAwareModelFails() {
 		B b = new B();
 		b.cs.add(new C());
 
 		PropertyModel<List<C>> target = new PropertyModel<List<C>>(b, "cs");
 
-		try {
-			model(from(target).get(0).getString());
-			
-			fail();
-		} catch (ClassCastException expected) {
-		}
+		model(from(target).get(0).getString());
+		
+		fail();
 	}
 
 	@Test
@@ -741,6 +739,19 @@ public class LazyModelTest {
 	@Test
 	public void getPath() {
 		assertEquals("b.cs.size()", path(from(A.class).getB().getCs().size()));
+	}
+	
+	@Test
+	public void bindUnboundLazyModelToNonIObjectClassAwareModel() {
+		LazyModel<B> model = model(from(A.class).getB());
+		
+		final A a = new A();
+		
+		B b = new B();
+		
+		model.bind(Model.of(b));
+		
+		assertEquals(B.class, ((IObjectClassAwareModel<B>) model.bind(Model.of(a))).getObjectClass());
 	}
 	
 	public static class A implements Serializable {


### PR DESCRIPTION
I made LazyModel hold a reference to the original target class, then pass it to any Evaluation and bound LazyModel objects it creates. That way, it works even if it is bound to a plain IModel.

I don't know if it fits the quality requirements for wicketstuff, but let me know if any additional change is needed.
