### PR TITLE
Make StatelessEncoder merge indexed parameters before jsessionid

### DIFF
--- a/jdk-1.6-parent/stateless-parent/stateless/src/main/java/org/wicketstuff/stateless/StatelessEncoder.java
+++ b/jdk-1.6-parent/stateless-parent/stateless/src/main/java/org/wicketstuff/stateless/StatelessEncoder.java
@@ -3,6 +3,7 @@ package org.wicketstuff.stateless;
 import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.List;
 
 import org.apache.wicket.request.Url;
 import org.apache.wicket.request.mapper.parameter.INamedParameters;
@@ -41,9 +42,28 @@ final class StatelessEncoder
         Set<String> setParameters = new HashSet<String>();
 
         int indexedCount = params.getIndexedCount();
-        for (int i = 0; i < indexedCount; i++)
+        if (indexedCount > 0) 
         {
-            mergedUrl.getSegments().add(params.get(i).toString());
+            String jsessionidString = null;
+            List<String> segments = mergedUrl.getSegments();
+            if (segments.size() > 0) 
+            {
+                String lastSegment = segments.get(segments.size() - 1);
+                int jsessionidIndex = lastSegment.indexOf(";jsessionid=");
+                if (jsessionidIndex != -1) 
+                {
+                   segments.set(segments.size() - 1, lastSegment.substring(0, jsessionidIndex));
+                   jsessionidString = lastSegment.substring(jsessionidIndex);
+                }
+            }
+            for (int i = 0; i < indexedCount; i++)
+            {
+                segments.add(params.get(i).toString());
+            }
+            if (jsessionidString != null)
+            {
+                segments.set(segments.size() - 1, segments.get(segments.size() - 1).concat(jsessionidString));
+            }
         }
 
         for (INamedParameters.NamedPair pair : params.getAllNamed())

--- a/jdk-1.6-parent/stateless-parent/stateless/src/test/java/org/wicketstuff/stateless/StatelessEncoderTest.java
+++ b/jdk-1.6-parent/stateless-parent/stateless/src/test/java/org/wicketstuff/stateless/StatelessEncoderTest.java
@@ -78,4 +78,19 @@ public class StatelessEncoderTest {
         // XXX compares Map content vs. its toString(). Improve the assertion!
         assertEquals(Url.parse("val1/val2?test2=val3&test2=val4"), encoded);
     }
+
+    @Test
+    public void putIndexedParametersBeforeJsessionId()
+    {
+        Url originalUrl = Url.parse("/wicket/page;jsessionid=1255ckl9n31uj1baf4wv9yqv7r?0-1.ILinkListener-link");
+        final PageParameters params = new PageParameters();
+
+        params.set(0, "val1");
+        params.set(1, "val2");
+        params.add("test2", new String[] { "val3", "val4" });
+
+        final Url encoded = StatelessEncoder.mergeParameters(originalUrl, params);
+
+        assertEquals(Url.parse("/wicket/page/val1/val2;jsessionid=1255ckl9n31uj1baf4wv9yqv7r?0-1.ILinkListener-link&test2=val3&test2=val4"), encoded);
+    }
 }


### PR DESCRIPTION
After fix to #223 StatelessEncoder merges indexed parameters into url, but if there is a jsessionid appended to the url then the parameters go after it. These are changes I made as a workaround.
Revisited quickstart to show the problem: http://www.ahr.com.pl/statelesslink-issue.tgz After you disable cookies and visit stateful page the links won't work.
