### PR TITLE
Add Glassfish 4 Integration Package with custom ISerializer for EJB support.

### DIFF
--- a/jdk-1.7-parent/pom.xml
+++ b/jdk-1.7-parent/pom.xml
@@ -20,6 +20,7 @@
 
 	<modules>
 		<module>wicketstuff-wicket7</module>
+		<module>wicketstuff-glassfish4-integration</module>
 	</modules>
 
 	<build>

--- a/jdk-1.7-parent/wicketstuff-glassfish4-integration/pom.xml
+++ b/jdk-1.7-parent/wicketstuff-glassfish4-integration/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wicketstuff</groupId>
+        <artifactId>jdk-1.7-parent</artifactId>
+        <version>6.0-SNAPSHOT</version>
+    </parent>
+    <groupId>com.viewsystems</groupId>
+    <artifactId>wicketstuff-glassfish4-integration</artifactId>
+    <packaging>jar</packaging>
+    <name>WicketStuff Glassfish Integration</name>
+    <description>
+        Provides custom serializer compatible with Glassfish 4.0. This prevents serialization issues when classes
+        use cdi injection in the glassfish app server.
+    </description>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.wicket</groupId>
+            <artifactId>wicket-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.main.extras</groupId>
+            <artifactId>glassfish-embedded-all</artifactId>
+            <version>4.0</version>
+            <scope>provided</scope>
+        </dependency> 
+    </dependencies>
+</project>

--- a/jdk-1.7-parent/wicketstuff-glassfish4-integration/src/main/java/com/viewsystems/wicketstuff/cdi/glassfish/GlassfishSerializer.java
+++ b/jdk-1.7-parent/wicketstuff-glassfish4-integration/src/main/java/com/viewsystems/wicketstuff/cdi/glassfish/GlassfishSerializer.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.viewsystems.wicketstuff.cdi.glassfish;
+
+import com.sun.enterprise.container.common.spi.util.JavaEEObjectInputStream;
+import com.sun.enterprise.container.common.spi.util.JavaEEObjectOutputStream;
+import com.sun.enterprise.container.common.spi.util.JavaEEObjectStreamHandler;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.apache.wicket.serialize.ISerializer;
+import org.apache.wicket.util.lang.Args;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Allows for Glassfish Proxy objects to be serialized and de-serialized when using CDI Works with
+ * GF 3.1 GF 3.1.2 GF 4.0 Must include glassfish-embedded-all for compile only it is provided in app
+ * server so don't add to the war Example Usage:
+ * 
+ * <pre>
+ * 
+ * protected void init()
+ * {
+ * 	super.init();
+ * 	try
+ * 	{
+ * 		BeanManager beanManager = (BeanManager)new InitialContext().lookup(&quot;java:comp/BeanManager&quot;);
+ * 
+ * 		new CdiConfiguration(beanManager).setPropagation(ConversationPropagation.NONBOOKMARKABLE)
+ * 			.configure(this);
+ * 		getFrameworkSettings().setSerializer(
+ * 			new GlassfishSerializer(getFrameworkSettings().getSerializer()));
+ * 	}
+ * 	catch (NamingException ne)
+ * 	{
+ * 		throw new RuntimeException(ne);
+ * 	}
+ * }
+ * </pre>
+ * 
+ * @author jsarman
+ */
+public class GlassfishSerializer implements ISerializer
+{
+
+	private static final Logger LOG = LoggerFactory.getLogger(GlassfishSerializer.class);
+	private ISerializer fallback;
+
+	public GlassfishSerializer(ISerializer fallback)
+	{
+		Args.notNull(fallback, "Fallback Serializer");
+		this.fallback = fallback;
+	}
+
+	@Override
+	public Object deserialize(byte[] data) {
+		try {
+			ByteArrayInputStream bais = new ByteArrayInputStream(data);
+			Collection<JavaEEObjectStreamHandler> handlers = new ArrayList<>();
+			handlers.add(getHandler());
+			JavaEEObjectInputStream q = new JavaEEObjectInputStream(bais,
+					getClass().getClassLoader(), true, handlers);
+			return q.readObject();
+		} catch (Exception e) {
+			LOG.warn(
+					"Caught Exception attempting to deserialize. Falling Back\n {} ",
+					e);
+			return fallback.deserialize(data);
+		}
+	}
+
+	@Override
+	public byte[] serialize(Object object) {
+		try {
+			ByteArrayOutputStream baos = new ByteArrayOutputStream();
+			Collection<JavaEEObjectStreamHandler> handlers = new ArrayList<>();
+			handlers.add(getHandler());
+			JavaEEObjectOutputStream oos = new JavaEEObjectOutputStream(baos,
+					true, handlers);
+			oos.writeObject(object);
+			return baos.toByteArray();
+		} catch (Exception e) {
+			LOG.warn(
+					"Caught Exception attempting to serialize. Falling Back\n {} ",
+					e);
+			return fallback.serialize(object);
+		}
+	}
+
+	private JavaEEObjectStreamHandler getHandler() throws Exception
+	{
+		return new GlassfishStreamHandler();
+	}
+
+	public static class GlassfishStreamHandler implements JavaEEObjectStreamHandler
+	{
+
+		private Class indirectlySerializableClass;
+		private Class serializableObjectFactoryClass;
+
+		public GlassfishStreamHandler() throws ClassNotFoundException
+		{
+
+			try
+			{
+				indirectlySerializableClass = Class.forName("com.sun.ejb.spi.io.IndirectlySerializable");
+				serializableObjectFactoryClass = Class.forName("com.sun.ejb.spi.io.SerializableObjectFactory");
+
+			}
+			catch (ClassNotFoundException cnfe)
+			{
+				indirectlySerializableClass = Class.forName("com.sun.enterprise.container.common.spi.util.IndirectlySerializable");
+				serializableObjectFactoryClass = Class.forName("com.sun.enterprise.container.common.spi.util.SerializableObjectFactory");
+
+			}
+
+		}
+
+		@Override
+		public Object replaceObject(Object obj) throws IOException {
+			Object result = obj;
+			try {
+				if (indirectlySerializableClass
+						.isAssignableFrom(obj.getClass())) {
+					result = indirectlySerializableClass.getMethod(
+							"getSerializableObjectFactory", new Class[] {})
+							.invoke(obj, new Object[] {}); 
+				}
+			} catch (NoSuchMethodException | SecurityException
+					| IllegalAccessException | IllegalArgumentException
+					| InvocationTargetException e) {
+				LOG.error("Caught Exception in replaceObject", e);
+			}
+			return result;
+		}
+
+		@Override
+		public Object resolveObject(Object obj) throws IOException {
+			Object result = obj;
+			try {
+				if (serializableObjectFactoryClass.isAssignableFrom(obj
+						.getClass())) {
+										
+					result = serializableObjectFactoryClass.getMethod(
+							"createObject", new Class[] {}).invoke(obj,
+							new Object[] {});												
+				}
+			} catch (NoSuchMethodException | SecurityException
+					| IllegalAccessException | IllegalArgumentException
+					| InvocationTargetException e) {
+				LOG.error("Caught Exception in resolveObject", e);
+			}
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
This initial commit adds a custom serializer that can properly serialize
and deserialize objects that are EJB's.  Without the serializer Wicket
will not be able to properly cache pages for the back button.
