### PR TITLE
Make double click event works in GMap3 examples

### DIFF
--- a/jdk-1.6-parent/gmap3-parent/gmap3-examples/src/main/java/org/wicketstuff/examples/gmap/listen/overlay/advanced/HomePage.java
+++ b/jdk-1.6-parent/gmap3-parent/gmap3-examples/src/main/java/org/wicketstuff/examples/gmap/listen/overlay/advanced/HomePage.java
@@ -169,7 +169,7 @@ public class HomePage extends WicketExamplePage
                 protected void onEvent(AjaxRequestTarget target)
                 {
                     MyMarker overlay = ((MyMarker) GOverlayPanel.this.getDefaultModelObject());
-                    if ((Boolean) dragendLabel.getDefaultModelObject())
+                    if ((Boolean) dblclickLabel.getDefaultModelObject())
                     {
                         overlay.clearListeners(GEvent.dblclick);
                     }


### PR DESCRIPTION
Double click event in the "listen" example was not working.
A test was using a wrong component.
