### PR TITLE
Fixed bug where loginPage in annotation would be ignored

### DIFF
--- a/jdk-1.6-parent/shiro-security/wicket-shiro/src/main/java/org/wicketstuff/shiro/authz/ShiroUnauthorizedComponentListener.java
+++ b/jdk-1.6-parent/shiro-security/wicket-shiro/src/main/java/org/wicketstuff/shiro/authz/ShiroUnauthorizedComponentListener.java
@@ -85,16 +85,16 @@ public class ShiroUnauthorizedComponentListener implements
 	{
 		final Subject subject = SecurityUtils.getSubject();
 		final boolean notLoggedIn = !subject.isAuthenticated();
-		final Class<? extends Page> page = notLoggedIn ? loginPage : unauthorizedPage;
+		Class<? extends Page> page = notLoggedIn ? loginPage : unauthorizedPage;
 
 		if (annotationStrategy != null)
 		{
 			final ShiroSecurityConstraint fail = annotationStrategy.checkInvalidInstantiation(component.getClass());
 			if (fail != null)
 				if (notLoggedIn)
-					addLoginMessagesAndGetPage(fail, component, page);
+					page = addLoginMessagesAndGetPage(fail, component, page);
 				else
-					addUnauthorizedMessagesAndGetPage(fail, component, page);
+					page = addUnauthorizedMessagesAndGetPage(fail, component, page);
 		}
 
 		if (notLoggedIn)


### PR DESCRIPTION
Declaring the variable page final prevented the Listener from using a page class specified in the annotation therefore always redirecting the user to the default login page.
