### PR TITLE
Fixed package name to match folder structure

### DIFF
--- a/jdk-1.6-parent/scala-extensions-parent/wicket-scala/src/main/scala/org/wicketstuff/scala/FutureModel.scala
+++ b/jdk-1.6-parent/scala-extensions-parent/wicket-scala/src/main/scala/org/wicketstuff/scala/FutureModel.scala
@@ -1,4 +1,4 @@
-package org.wickststuff.scala
+package org.wicketstuff.scala
 
 import java.util.concurrent.Executors
 import org.apache.wicket.model.AbstractReadOnlyModel


### PR DESCRIPTION
As package declaration was different than folder structure, source lookup does not work in IDEs like Eclipse.
