### PR TITLE
Memory leak + Escape key submitting changes in editable Grid

### DIFF
--- a/jdk-1.7-parent/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/common/res/script-jq.js
+++ b/jdk-1.7-parent/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/common/res/script-jq.js
@@ -81,6 +81,12 @@ if (typeof(InMethod) === "undefined") {
 					// remove all events.
 					$(e).off();
 					++purgedCount;
+				} 
+                                // Solves Memory leak
+                                else if(!jQuery.contains(document, e)){
+                                    $(e).off();
+                                    $(e).remove();
+                                    ++purgedCount;
 				} else {
 					// element is still in document, return it
 					elementsWithListeners.push(e);


### PR DESCRIPTION
Solved two issues.
First one regarding keyEvent always submitting changes
https://github.com/wicketstuff/core/issues/311#issuecomment-46562195

The other one regarding a memory leak caused by events not being purged in the jquery version of the script.

Both changes have been tested, and are apparently working fine.
