### PR TITLE
Updated Wicket AJAX calls.

### DIFF
--- a/jdk-1.7-parent/openlayers-parent/openlayers/src/main/java/org/wicketstuff/openlayers/wicket-openlayersmap.js
+++ b/jdk-1.7-parent/openlayers-parent/openlayers/src/main/java/org/wicketstuff/openlayers/wicket-openlayersmap.js
@@ -64,13 +64,9 @@ function WicketOMap(id, options, markersLayerName, showMarkersInLayerSwitcher) {
 		params["centerConverted"] = this.businessLogicProjection != null ? this.map.getCenter().clone().transform(this.map.getProjectionObject(), new OpenLayers.Projection(this.businessLogicProjection)) : this.map.getCenter();
 		params["boundsConverted"] = this.businessLogicProjection != null ? this.map.getExtent().clone().transform(this.map.getProjectionObject(), new OpenLayers.Projection(this.businessLogicProjection)) : this.map.getExtent();
 		params["zoomConverted"] = this.map.getZoomForExtent(this.map.getExtent(), true);
-		for (var key in params) {
-			callBack = callBack + "&" + key + "=" + params[key];
-		}
-		wicketAjaxGet(callBack, function () {
-		}, function () {
-		});
-	};
+        Wicket.Ajax.post({u: callBack,
+            dep: [function(){return params;}]});
+    };
 	this.addLayer = function (layer, id) {
 		var self = this;
 		self.map.addLayer(layer);
@@ -123,9 +119,8 @@ function WicketOMap(id, options, markersLayerName, showMarkersInLayerSwitcher) {
 		if (evt != null) {
 			event = evt.type;
 		}
-		callBack = callBack + "&event=" + event;
-		var wcall = wicketAjaxGet(callBack, function () {
-		}, null, null);
+        var wcall = Wicket.Ajax.post({u: callBack,
+            dep: [function(){return {event: event}; }]});
 	};
 	this.getMarker = function (markerId) {
 		var self = this;
@@ -242,9 +237,8 @@ function WicketOMap(id, options, markersLayerName, showMarkersInLayerSwitcher) {
 	                    };   
 	                var format =new OpenLayers.Format.WKT(in_options);
 	                var str = format.write(e.feature, false);
-
-					var callModded = callBack + "&wkt=" + str;
-					var wcall = wicketAjaxGet(callModded, function () {}, null, null);
+                    var wcall = Wicket.Ajax.post({u: callBack,
+                        dep: [function(){return {wkt: str}; }]});
         	    }
     	    });
 	    }


### PR DESCRIPTION
The format for Wicket AJAX calls has changed with version 6. I have
updated the library to use this new format.

---

I have only been working with this code base for a week, but I've already found a couple cases where the difference between OpenLayers 2.9 and 2.13 is becoming significant. For instance, it looks like this library would like all markers attached directly to the map overlay but OL 2.13 has a layer type where you can place your markers. In addition, it looks like OL is making steady progress towards releasing version 3.

I am considering re-implementing the Wicket OpenLayers support and targeting their 3.x series. I would be very pleased to contribute the code back to this project, if you're interested, and am also interested in your opinion (if you anyone has one).

Thank you!
