### PR TITLE
async-tasks-impl: Adding refreshBehavior in ProgressButton ctor if task ...

### DIFF
--- a/jdk-1.7-parent/async-tasks-parent/async-tasks-impl/src/main/java/org/wicketstuff/async/components/ProgressButton.java
+++ b/jdk-1.7-parent/async-tasks-parent/async-tasks-impl/src/main/java/org/wicketstuff/async/components/ProgressButton.java
@@ -57,7 +57,9 @@ public class ProgressButton extends AjaxFallbackButton {
         this.refreshDependants = new HashSet<Component>();
 
         this.refreshBehavior = new RefreshBehavior(duration);
-
+        if (getTaskContainer().isRunning()) {
+            add(refreshBehavior);
+        }
         this.stateTextModels = new HashMap<StateDescription, IModel<String>>();
         this.setModel(new StateDispatcherModel<String>(getDefaultTextModel(model), stateTextModels));
 


### PR DESCRIPTION
...container already running:

If a user starts a long running task and leaves the page with the ProgressButton, when coming back to the page again, the ProgressButton should showing and updating the current progress. I tried to implement this by passing the already running task container to the ProgressButton when the page is re-created. This, however, doesn't work since the ProgressButton implementation doesn't add the refresh behavior to the button in the ctor. This patch could fix this behavior.
