### PR TITLE
Enhancement to annotation event dispatcher: unwrap and rethrow ReplaceHandlerExceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ META-INF
 nb-configuration.xml
 *~
 rebel.xml
+.springBeans

--- a/jdk-1.7-parent/annotationeventdispatcher-parent/annotationeventdispatcher/src/main/java/org/wicketstuff/event/annotation/AnnotationEventSink.java
+++ b/jdk-1.7-parent/annotationeventdispatcher-parent/annotationeventdispatcher/src/main/java/org/wicketstuff/event/annotation/AnnotationEventSink.java
@@ -20,17 +20,18 @@ import static java.lang.reflect.Modifier.isPublic;
 import static java.util.Arrays.asList;
 import static org.apache.wicket.RuntimeConfigurationType.DEVELOPMENT;
 
-import org.apache.wicket.Application;
-import org.apache.wicket.Component;
-import org.apache.wicket.event.IEvent;
-import org.apache.wicket.util.collections.ClassMetaCache;
-import org.apache.wicket.util.visit.Visit;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import org.apache.wicket.Application;
+import org.apache.wicket.Component;
+import org.apache.wicket.event.IEvent;
+import org.apache.wicket.request.RequestHandlerStack.ReplaceHandlerException;
+import org.apache.wicket.util.collections.ClassMetaCache;
+import org.apache.wicket.util.visit.Visit;
 
 class AnnotationEventSink
 {
@@ -163,7 +164,14 @@ class AnnotationEventSink
 			}
 		} catch (InvocationTargetException e)
 		{
-			throw new IllegalStateException("Failed to invoke @OnEvent method", e);
+			if (e.getCause() instanceof ReplaceHandlerException)
+			{
+				throw ((ReplaceHandlerException)e.getCause());
+			}
+			else
+			{
+				throw new IllegalStateException("Failed to invoke @OnEvent method", e);
+			}
 		} catch (IllegalAccessException e)
 		{
 			throw new IllegalStateException("Failed to invoke @OnEvent method", e);

--- a/jdk-1.7-parent/annotationeventdispatcher-parent/annotationeventdispatcher/src/test/java/org/wicketstuff/event/annotation/TypedAnnotationEventDispatcherTest.java
+++ b/jdk-1.7-parent/annotationeventdispatcher-parent/annotationeventdispatcher/src/test/java/org/wicketstuff/event/annotation/TypedAnnotationEventDispatcherTest.java
@@ -1,6 +1,8 @@
 package org.wicketstuff.event.annotation;
 
 import org.apache.wicket.Component;
+import org.apache.wicket.Page;
+import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.event.Broadcast;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -130,6 +132,21 @@ public class TypedAnnotationEventDispatcherTest
 		two.send(container.getApplication(), Broadcast.BREADTH, new SaveEvent<>(null, new Person()));
 	}
 	
+	/**
+	 * https://github.com/wicketstuff/core/pull/353
+	 */
+	@Test(expected = RestartResponseException.class)
+	public void replaceHandlerExceptionPropogated()
+	{
+		ComponentTwo two = new ComponentTwo("id1");
+		ComponentThree three = new ComponentThree("id2");
+		TestContainer container = new TestContainer("container");
+		container.add(two, three);
+		tester.startComponentInPage(container);
+		two.send(container.getApplication(), Broadcast.BREADTH, new SaveEvent<Company>(null,
+			new Company()));
+	}
+
 	private class Person {
 		
 	}
@@ -138,6 +155,11 @@ public class TypedAnnotationEventDispatcherTest
 		
 	}
 	
+	private class Company
+	{
+
+	}
+
 	class SuperWidget extends Widget {
 		
 	}
@@ -175,6 +197,14 @@ public class TypedAnnotationEventDispatcherTest
 			personsHandled++;
 		}
 		
+		@OnEvent(types = Company.class)
+		public void handleCompanyPersonEvent(final SaveEvent<Company> event)
+		{
+			throw new RestartResponseException(new Page()
+			{
+			});
+		}
+
 	}
 
 	private class ComponentOne extends AbstractTestComponent


### PR DESCRIPTION
Already committed on the 6.x branch --

Added .springBeans (Eclipse Spring IDE generated file) to .gitignore.
In the annotation event sink, add logic to allow wrapped exceptions of
type ReplaceHandlerException to be unwrapped and thrown rather than
being rewrapped and thrown. This allows, for example, a
NonResettingRestartException to be thrown from an event handler and
things work as expected.
