### PR TITLE
Models that depend on other models and behaviors for component visibility/enabling based on models

### DIFF
--- a/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/behavior/DependentModelBehavior.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/behavior/DependentModelBehavior.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.behavior;
+
+import java.util.Objects;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.behavior.Behavior;
+import org.apache.wicket.model.IModel;
+
+/**
+ * Behavior that uses the value of the dependent model. The dependent model is detached when the
+ * behavior is detached.
+ * 
+ * @param <D>
+ *            the type of the model this behavior depends on
+ */
+public abstract class DependentModelBehavior<D> extends Behavior
+{
+
+	private final IModel<D> dependentModel;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param dependentModel
+	 *            model the behavior is dependent on
+	 */
+	public DependentModelBehavior(final IModel<D> dependentModel)
+	{
+		Objects.requireNonNull(dependentModel, "The dependent model must not be null.");
+		this.dependentModel = dependentModel;
+	}
+
+	@Override
+	public void detach(final Component component)
+	{
+		super.detach(component);
+		dependentModel.detach();
+	}
+
+	/**
+	 * Returns the model the behavior depends on.
+	 * 
+	 * @return the model the behavior depends on
+	 */
+	protected IModel<D> getDependentModel()
+	{
+		return dependentModel;
+	}
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/behavior/EnabledModelBehavior.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/behavior/EnabledModelBehavior.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.behavior;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.model.IModel;
+
+/**
+ * Behavior that sets whether a component is enabled based on the value of the dependent Boolean
+ * model.
+ */
+public class EnabledModelBehavior extends DependentModelBehavior<Boolean>
+{
+
+    /**
+	 * Constructor.
+	 *
+	 * @param dependentModel
+	 *            model of whether the component should be enabled
+	 */
+	public EnabledModelBehavior(final IModel<Boolean> dependentModel)
+	{
+		super(dependentModel);
+    }
+
+    @Override
+    public void onConfigure(final Component component) {
+        super.onConfigure(component);
+		Boolean enabled = getDependentModel().getObject();
+		component.setEnabled(enabled != null && enabled);
+    }
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/behavior/HideWhenEmptyOrNullBehavior.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/behavior/HideWhenEmptyOrNullBehavior.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.behavior;
+
+import java.util.Collection;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.behavior.Behavior;
+import org.apache.wicket.util.string.Strings;
+
+/**
+ * Hides a component if the component's model value is empty or null.
+ */
+public class HideWhenEmptyOrNullBehavior extends Behavior {
+
+    private static final Behavior INSTANCE = new HideWhenEmptyOrNullBehavior();
+
+    /**
+	 * Returns the instance of the behavior.
+	 *
+	 * @return instance of the behavior
+	 */
+    public static Behavior get() {
+        return INSTANCE;
+    }
+
+    /**
+     * Private constructor.
+     */
+    private HideWhenEmptyOrNullBehavior() {
+        super();
+    }
+
+    @Override
+    public void onConfigure(final Component component) {
+        super.onConfigure(component);
+		Object dependentValue = component.getDefaultModelObject();
+		boolean visible;
+		if (dependentValue instanceof Collection)
+		{
+			final Collection<?> c = (Collection<?>)dependentValue;
+			visible = !c.isEmpty();
+		}
+		else if (dependentValue instanceof CharSequence)
+		{
+			visible = !Strings.isEmpty((CharSequence)dependentValue);
+		}
+		else
+		{
+			visible = dependentValue != null;
+		}
+		component.setVisible(visible);
+    }
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/behavior/VisibleModelBehavior.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/behavior/VisibleModelBehavior.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.behavior;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.model.IModel;
+
+/**
+ * Behavior that sets whether a component is visible based on the value of the dependent Boolean
+ * model.
+ */
+public class VisibleModelBehavior extends DependentModelBehavior<Boolean>
+{
+
+	/**
+	 * Constructor.
+	 *
+	 * @param dependentModel
+	 *            model of whether the component should be visible
+	 */
+	public VisibleModelBehavior(final IModel<Boolean> dependentModel)
+	{
+		super(dependentModel);
+	}
+
+	@Override
+	public void onConfigure(final Component component)
+	{
+		super.onConfigure(component);
+		Boolean visible = getDependentModel().getObject();
+		component.setVisible(visible != null && visible);
+	}
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/model/IsEmptyOrNullModel.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/model/IsEmptyOrNullModel.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.model;
+
+import java.util.Collection;
+
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.string.Strings;
+
+/**
+ * Model of whether the object of the dependent model is empty or null.
+ *
+ * @param <W>
+ *            type of the dependent model
+ */
+public class IsEmptyOrNullModel<W> extends LoadableDetachableDependentModel<Boolean, W>
+{
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param dependentModel
+	 *            non-null collection model this model depends on
+	 */
+	public IsEmptyOrNullModel(IModel<W> dependentModel)
+	{
+		super(dependentModel);
+	}
+
+	@Override
+	protected Boolean load()
+	{
+		boolean empty = true;
+		W dependentValue = getDependentModel().getObject();
+		if (dependentValue instanceof Collection)
+		{
+			empty = ((Collection<?>)dependentValue).isEmpty();
+		}
+		else if (dependentValue instanceof CharSequence)
+		{
+			empty = Strings.isEmpty((CharSequence)dependentValue);
+		}
+		else
+		{
+			empty = dependentValue == null;
+		}
+		return empty;
+	}
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/model/LoadableDetachableDependentModel.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/model/LoadableDetachableDependentModel.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.model;
+
+import java.util.Objects;
+
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
+
+/**
+ * {@link LoadableDetachableModel} that is dependent on another model. The dependent model is
+ * detached when this model is detached.
+ * 
+ * @param <T>
+ *            type of this model
+ * @param <D>
+ *            type of model this model is dependent on
+ */
+public abstract class LoadableDetachableDependentModel<T, D> extends LoadableDetachableModel<T>
+{
+
+	private IModel<D> dependentModel;
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param dependentModel
+	 *            non-null model this model depends on
+	 */
+	public LoadableDetachableDependentModel(IModel<D> dependentModel)
+	{
+		Objects.requireNonNull(dependentModel, "The dependent model cannot be null.");
+		this.dependentModel = dependentModel;
+	}
+
+	/**
+	 * Returns the model this model depends on.
+	 * 
+	 * @return the model this model depends on
+	 */
+	public IModel<D> getDependentModel()
+	{
+		return dependentModel;
+	}
+
+	@Override
+	protected void onDetach()
+	{
+		super.onDetach();
+		dependentModel.detach();
+	}
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/model/NotModel.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/main/java/org/wicketstuff/minis/model/NotModel.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.model;
+
+import org.apache.wicket.model.IModel;
+
+/**
+ * Boolean model that returns the opposite of the dependent Boolean model value. The value returned
+ * when the dependent model value is null is configurable -- it defaults to true.
+ */
+public class NotModel extends LoadableDetachableDependentModel<Boolean, Boolean>
+{
+
+	private boolean nullValue;
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param dependentModel
+	 *            non-null model this model depends on
+	 */
+	public NotModel(IModel<Boolean> dependentModel)
+	{
+		this(dependentModel, true);
+	}
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param dependentModel
+	 *            non-null model this model depends on
+	 * @param nullValue
+	 *            the value load() will return if the dependent model value is null
+	 */
+	public NotModel(IModel<Boolean> dependentModel, boolean nullValue)
+	{
+		super(dependentModel);
+		this.nullValue = nullValue;
+	}
+
+	@Override
+	protected Boolean load()
+	{
+		Boolean b = getDependentModel().getObject();
+		return b == null ? nullValue : !b;
+	}
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/behavior/EnabledModelBehaviorTest.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/behavior/EnabledModelBehaviorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.behavior;
+
+import org.apache.wicket.markup.Markup;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.TagTester;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EnabledModelBehaviorTest
+{
+
+	private static final String DISABLED_ATTR = "disabled";
+	private static final String CID_FIELD = "field";
+	private static final String MARKUP = "<input type=\"text\" wicket:id=\"" + CID_FIELD + "\"/>";
+
+	private final WicketTester tester = new WicketTester();
+
+	@After
+	public void after()
+	{
+		tester.destroy();
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testNullDependentModelThrowsNPE()
+	{
+		new TextField<>("field").add(new EnabledModelBehavior(null));
+	}
+
+	@Test
+	public void testComponentNotEnabledOnFalseModel()
+	{
+		tester.startComponentInPage(
+			new TextField<>(CID_FIELD).add(new EnabledModelBehavior(Model.of(false))),
+			Markup.of(MARKUP));
+		TagTester tagTester = tester.getTagByWicketId(CID_FIELD);
+		Assert.assertNotNull(tagTester.getAttribute(DISABLED_ATTR));
+	}
+
+	@Test
+	public void testComponentEnabledOnTrueModel()
+	{
+		tester.startComponentInPage(
+			new TextField<>(CID_FIELD).add(new EnabledModelBehavior(Model.of(true))),
+			Markup.of(MARKUP));
+		TagTester tagTester = tester.getTagByWicketId(CID_FIELD);
+		Assert.assertNull(tagTester.getAttribute(DISABLED_ATTR));
+	}
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/behavior/HideWhenEmptyOrNullBehaviorTest.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/behavior/HideWhenEmptyOrNullBehaviorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.behavior;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.wicket.markup.Markup;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.util.ListModel;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HideWhenEmptyOrNullBehaviorTest
+{
+
+	private static final String CID_LABEL = "label";
+	private static final String MARKUP = "<span wicket:id=\"" + CID_LABEL + "\"></span>";
+
+	private final WicketTester tester = new WicketTester();
+
+	@After
+	public void after()
+	{
+		tester.destroy();
+	}
+
+	@Test
+	public void testComponentNotPresentOnNullModel()
+	{
+		tester.startComponentInPage(
+			new Label(CID_LABEL, Model.of((Serializable)null)).add(HideWhenEmptyOrNullBehavior.get()),
+			Markup.of(MARKUP));
+		Assert.assertNull(tester.getTagByWicketId(CID_LABEL));
+	}
+
+	@Test
+	public void testComponentPresentOnNotNullModel()
+	{
+		tester.startComponentInPage(
+			new Label(CID_LABEL, Model.of(1)).add(HideWhenEmptyOrNullBehavior.get()),
+			Markup.of(MARKUP));
+		Assert.assertNotNull(tester.getTagByWicketId(CID_LABEL));
+	}
+
+	@Test
+	public void testComponentNotPresentOnEmptyStringModel()
+	{
+		tester.startComponentInPage(
+			new Label(CID_LABEL, Model.of("")).add(HideWhenEmptyOrNullBehavior.get()),
+			Markup.of(MARKUP));
+		Assert.assertNull(tester.getTagByWicketId(CID_LABEL));
+	}
+
+	@Test
+	public void testComponentPresentOnNonEmptyStringModel()
+	{
+		tester.startComponentInPage(
+			new Label(CID_LABEL, Model.of("test")).add(HideWhenEmptyOrNullBehavior.get()),
+			Markup.of(MARKUP));
+		Assert.assertNotNull(tester.getTagByWicketId(CID_LABEL));
+	}
+
+	@Test
+	public void testComponentNotPresentOnEmptyCollectionModel()
+	{
+		tester.startComponentInPage(
+			new Label(CID_LABEL, new ListModel<>(Collections.emptyList())).add(HideWhenEmptyOrNullBehavior.get()),
+			Markup.of(MARKUP));
+		Assert.assertNull(tester.getTagByWicketId(CID_LABEL));
+	}
+
+	@Test
+	public void testComponentPresentOnNonEmptyCollectionModel()
+	{
+		tester.startComponentInPage(
+			new Label(CID_LABEL, new ListModel<>(Arrays.asList("test"))).add(HideWhenEmptyOrNullBehavior.get()),
+			Markup.of(MARKUP));
+		Assert.assertNotNull(tester.getTagByWicketId(CID_LABEL));
+	}
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/behavior/VisibleModelBehaviorTest.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/behavior/VisibleModelBehaviorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.behavior;
+
+import org.apache.wicket.markup.Markup;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class VisibleModelBehaviorTest
+{
+
+	private static final String CID_LABEL = "label";
+	private static final String MARKUP = "<span wicket:id=\"" + CID_LABEL + "\"></span>";
+
+	private final WicketTester tester = new WicketTester();
+
+	@After
+	public void after()
+	{
+		tester.destroy();
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testNullDependentModelThrowsNPE()
+	{
+		new Label(CID_LABEL).add(new VisibleModelBehavior(null));
+	}
+
+	@Test
+	public void testComponentNotPresentOnFalseModel()
+	{
+		tester.startComponentInPage(
+			new Label(CID_LABEL).add(new VisibleModelBehavior(Model.of(false))), Markup.of(MARKUP));
+		Assert.assertNull(tester.getTagByWicketId(CID_LABEL));
+	}
+
+	@Test
+	public void testComponentPresentOnTrueModel()
+	{
+		tester.startComponentInPage(
+			new Label(CID_LABEL).add(new VisibleModelBehavior(Model.of(true))), Markup.of(MARKUP));
+		Assert.assertNotNull(tester.getTagByWicketId(CID_LABEL));
+	}
+
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/model/IsEmptyOrNullModelTest.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/model/IsEmptyOrNullModelTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.model;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.util.ListModel;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IsEmptyOrNullModelTest
+{
+
+	@Test(expected = NullPointerException.class)
+	public void testNullDependentModelThrowsNPE()
+	{
+		new IsEmptyOrNullModel<>(null);
+	}
+
+	@Test
+	public void testNullModelValueYieldsTrue()
+	{
+		Assert.assertTrue(new IsEmptyOrNullModel<>(Model.of((Serializable)null)).getObject());
+	}
+
+	@Test
+	public void testNotNullModelValueYieldsFalse()
+	{
+		Assert.assertFalse(new IsEmptyOrNullModel<>(Model.of(1)).getObject());
+	}
+
+	@Test
+	public void testEmptyStringModelValueYieldsTrue()
+	{
+		Assert.assertTrue(new IsEmptyOrNullModel<>(Model.of("")).getObject());
+	}
+
+	@Test
+	public void testNonEmptyStringModelValueYielsFalse()
+	{
+		Assert.assertFalse(new IsEmptyOrNullModel<>(Model.of("test")).getObject());
+	}
+
+	@Test
+	public void testEmptyCollectionModelValueYieldsTrie()
+	{
+		Assert.assertTrue(new IsEmptyOrNullModel<>(new ListModel<>(Collections.emptyList())).getObject());
+	}
+
+	@Test
+	public void testComponentPresentOnNonEmptyCollectionModel()
+	{
+		Assert.assertFalse(new IsEmptyOrNullModel<>(new ListModel<>(Arrays.asList("test"))).getObject());
+	}
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/model/LoadableDetachableDependentModelTest.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/model/LoadableDetachableDependentModelTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.model;
+
+import org.apache.wicket.markup.Markup;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.model.LoadableDetachableModel;
+import org.apache.wicket.util.tester.WicketTester;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LoadableDetachableDependentModelTest
+{
+
+	private static final String CID_LABEL = "label";
+	private static final String MARKUP = "<span wicket:id=\"" + CID_LABEL + "\"></span>";
+
+	private final WicketTester tester = new WicketTester();
+
+	@After
+	public void after()
+	{
+		tester.destroy();
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void testNullDependentModelThrowsNPE()
+	{
+		new LoadableDetachableDependentModel<String, String>(null)
+		{
+
+			@Override
+			protected String load()
+			{
+				return "test";
+			}
+
+		};
+	}
+
+	@Test
+	public void testDependentModelIsSameAndDetached()
+	{
+
+		LoadableDetachableModel<String> dependentModel = new LoadableDetachableModel<String>()
+		{
+
+			@Override
+			protected String load()
+			{
+				return "test";
+			}
+		};
+
+		LoadableDetachableDependentModel<String, String> model = new LoadableDetachableDependentModel<String, String>(
+			dependentModel)
+		{
+
+			@Override
+			protected String load()
+			{
+				return "test";
+			}
+			
+		};
+		Assert.assertSame(dependentModel, model.getDependentModel());
+		tester.startComponentInPage(new Label(CID_LABEL, model), Markup.of(MARKUP));
+		Assert.assertFalse(dependentModel.isAttached());
+
+	}
+
+
+}

--- a/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/model/NotModelTest.java
+++ b/jdk-1.7-parent/minis-parent/minis/src/test/java/org/wicketstuff/minis/model/NotModelTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wicketstuff.minis.model;
+
+import org.apache.wicket.model.Model;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NotModelTest
+{
+
+	@Test(expected = NullPointerException.class)
+	public void testNullDependentModelThrowsNPE()
+	{
+		new NotModel(null);
+	}
+
+	@Test
+	public void testTrueDependentModelYieldsFalse()
+	{
+		Assert.assertFalse(new NotModel(Model.of(true)).getObject());
+	}
+
+	@Test
+	public void testFalseDependentModelYieldsTrue()
+	{
+		Assert.assertTrue(new NotModel(Model.of(false)).getObject());
+	}
+	
+	@Test
+	public void testNullDependentModelYieldsTrueByDefault()
+	{
+		Assert.assertTrue(new NotModel(Model.of((Boolean)null)).getObject());
+	}
+
+	@Test
+	public void testSpecifyNullDependentModelResult()
+	{
+		Assert.assertFalse(new NotModel(Model.of((Boolean)null), false).getObject());
+	}
+
+}


### PR DESCRIPTION
I've found that I often want to be able to transform a model of one type into a model of another type.  For example, perhaps I have an IModel&lt;String&gt; but what I really want is a model of whether the object of the model is empty.  To do this, I wrap a LDM<Boolean> around the IModel&lt;String&gt;.  

The LoadableDetachableDependentModel class in this pull request is a simple base class for dealing with these situations.  There are also a couple of concrete implementations of this class.  For example, if I want a model of whether a field is not empty I could do:

```
IModel<...> model = ...
IModel<Boolean> notEmptyModel = new NotModel<>(new IsEmptyOrNullModel<>(model));
```

The other part of this pull request is related to the visibility (and "enablement") of components.  The way this is currently done is one of:
1. call setVisible(...) on a component when it is created -- this won't change if the component is re-rendered
2. override onConfigure() for the component -- subclass the component
3. override onConfigure() in the container containing the component and specify setVisible(...) for the component there -- add an onConfigure() method to the container

This pull-request has a fourth way: add a behavior to a component that specifies its visibility (or "enablement").

The simplest example is the HideWhenEmptyOrNullBehavior:

```
new Label("label").add(HideWhenEmptyOrNullBehavior.get())
```

This will hide (setVisible(false)) when the model of the label is empty or null.

A more complicate example would be to be use VisibleModelBehavior:

```
IModel<...> model = ...
new TextField<>("field").add(VisibleModelBehavior(new NotModel<>(new IsEmptyOrNullModel<>(model))));
```

Change-log:
- Added a LDM class where the load()'ed value depends on another model.
- Added behaviors to hide/enable components based on a boolean model.
- Added a behavior to hide a component when the object of the component's
  model is empty or null.
- Added a couple of dependent models that are useful for composing models
  together.
