### PR TITLE
Adde ajaxFormSubmit to submit forms via AJAX.

### DIFF
--- a/jdk-1.7-parent/jee-web-parent/jee-web/src/main/java/org/wicketstuff/jeeweb/el/ELFunctions.java
+++ b/jdk-1.7-parent/jee-web-parent/jee-web/src/main/java/org/wicketstuff/jeeweb/el/ELFunctions.java
@@ -122,7 +122,8 @@ public class ELFunctions
 	}
 
 	/**
-	 * Creates a ajax callback function that processes a request to the current rendered page
+	 * Creates a ajax callback function that processes a request to the current rendered page.
+	 * It takes in input a query string.
 	 * 
 	 * @param query
 	 *            the query to be send to the function
@@ -131,5 +132,17 @@ public class ELFunctions
 	public static String ajaxGetWithQuery(String query)
 	{
 		return "Wicket.Ajax.get({'u':'" + ajaxCallbackUrlWithQuery(query) + "'});";
+	}
+	
+	/**
+	 * Creates a ajax callback function to send a form via AJAX to the current rendered page.
+	 * 
+	 * @param method
+	 * 			the request method that must be used (GET or POST).
+	 * @return the callback function
+	 */
+	public static String ajaxFormSubmit(String method)
+	{
+		return "Wicket.Ajax.ajax({'u':'" + ajaxCallbackUrl() + "', 'm':'" + method +"', 'f':this.id});return false;";
 	}
 }

--- a/jdk-1.7-parent/jee-web-parent/jee-web/src/main/resources/META-INF/faces.taglib.xml
+++ b/jdk-1.7-parent/jee-web-parent/jee-web/src/main/resources/META-INF/faces.taglib.xml
@@ -36,6 +36,12 @@
         <function-class>org.wicketstuff.jeeweb.el.ELFunctions</function-class>
         <function-signature>java.lang.String ajaxCallbackUrl()</function-signature>
     </function>
+    
+    <function>
+		<function-name>ajaxFormSubmit</function-name>
+		<function-class>org.wicketstuff.jeeweb.el.ELFunctions</function-class>
+		<function-signature>java.lang.String ajaxFormSubmit(java.lang.String)</function-signature>
+    </function>
 
     <tag>
 		<tag-name>url</tag-name>

--- a/jdk-1.7-parent/jee-web-parent/jee-web/src/main/resources/META-INF/jsp.taglib.tld
+++ b/jdk-1.7-parent/jee-web-parent/jee-web/src/main/resources/META-INF/jsp.taglib.tld
@@ -45,6 +45,12 @@
         <function-signature>java.lang.String ajaxCallbackUrl()</function-signature>
     </function>
     
+    <function>
+        <name>ajaxFormSubmit</name>
+        <function-class>org.wicketstuff.jeeweb.el.ELFunctions</function-class>
+        <function-signature>java.lang.String ajaxFormSubmit(java.lang.String)</function-signature>
+    </function>
+    
 	<tag>
 		<name>url</name>
 		<tagclass>org.wicketstuff.jeeweb.jsp.JspUrlTagSupport</tagclass>


### PR DESCRIPTION
Hi! I'd like to add the support for form submitting via AJAX from JSP/JSF. The current version works correctly if we put ajaxFormSubmit in the HTML form like this:

```
onsubmit="${wicket:ajaxFormSubmit('POST')}"
```

Let me know if you like it or not :)

@klopfdreh 
