### PR TITLE
[serializer-fast] [serializer-fast2] upgrade fast to 1.63 and 2.10

### DIFF
--- a/jdk-1.6-parent/serializer-fast/pom.xml
+++ b/jdk-1.6-parent/serializer-fast/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>de.ruedigermoeller</groupId>
       <artifactId>fst</artifactId>
-      <version>1.62</version>
+      <version>1.63</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.aggregate</groupId>

--- a/jdk-1.7-parent/serializer-fast2/pom.xml
+++ b/jdk-1.7-parent/serializer-fast2/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>de.ruedigermoeller</groupId>
       <artifactId>fst</artifactId>
-      <version>2.09</version>
+      <version>2.10</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.aggregate</groupId>


### PR DESCRIPTION
Fixes a bug regarding we spotted while testing our apps regarding the Externalizable support.
