### PR TITLE
CompoundRequestMapper: last registered mapper has highest priority

### DIFF
--- a/jdk-1.6-parent/annotation/src/main/java/org/wicketstuff/annotation/scan/AnnotatedMountScanner.java
+++ b/jdk-1.6-parent/annotation/src/main/java/org/wicketstuff/annotation/scan/AnnotatedMountScanner.java
@@ -216,22 +216,23 @@ public class AnnotatedMountScanner
 		if (mountPath == null)
 			return;
 
-		String path = mountPath.value();
-
-		// default if no explicit path is provided
-		if ("".equals(path))
-		{
-			path = getDefaultMountPath(pageClass);
-		}
-
-		list.add(getRequestMapper(path, pageClass));
-
 		// alternates
 		for (String alt : mountPath.alt())
 		{
 			list.add(getRequestMapper(alt, pageClass));
 		}
-	}
+
+        // CompoundRequestMapper: last registered mapper has highest priority
+        String path = mountPath.value();
+
+        // default if no explicit path is provided
+        if ("".equals(path))
+        {
+            path = getDefaultMountPath(pageClass);
+        }
+
+        list.add(getRequestMapper(path, pageClass));
+    }
 
 	/**
 	 * Returns the default mapper given a mount path and class.

--- a/jdk-1.6-parent/annotation/src/test/java/org/wicketstuff/annotation/scan/AnnotationTest.java
+++ b/jdk-1.6-parent/annotation/src/test/java/org/wicketstuff/annotation/scan/AnnotationTest.java
@@ -108,9 +108,9 @@ public class AnnotationTest extends TestCase
 		AnnotatedMountList list = testScanner.scanClass(ExplicitMountPathPage.class);
 		list = testScanner.scanClass(AlternativePathsPage.class);
 		assertEquals(3, list.size());
-		assertEquals("primary", ((TestMountedMapper)list.get(0)).mountPath);
-		assertEquals("alt1", ((TestMountedMapper)list.get(1)).mountPath);
-		assertEquals("alt2", ((TestMountedMapper)list.get(2)).mountPath);
+		assertEquals("alt1", ((TestMountedMapper)list.get(0)).mountPath);
+		assertEquals("alt2", ((TestMountedMapper)list.get(1)).mountPath);
+		assertEquals("primary", ((TestMountedMapper)list.get(2)).mountPath);
 	}
 
 	public void testPackageScan()


### PR DESCRIPTION
when using in Wicket with default CompoundRequestMapper the last alt was taken as default :-(
