### PR TITLE
Make StatelessEncoder public, because it's useful for appdevs to implement their own stateless components/behaviors

### DIFF
--- a/jdk-1.7-parent/stateless-parent/stateless/src/main/java/org/wicketstuff/stateless/StatelessEncoder.java
+++ b/jdk-1.7-parent/stateless-parent/stateless/src/main/java/org/wicketstuff/stateless/StatelessEncoder.java
@@ -15,7 +15,7 @@ import org.apache.wicket.util.encoding.UrlEncoder;
  * 
  * @author jfk
  */
-final class StatelessEncoder
+public class StatelessEncoder
 {
     /**
      * Merges the query parameters of the url with the named parameters


### PR DESCRIPTION
Make StatelessEncoder public, because it's useful for appdevs to implement their own stateless components/behaviors
