### PR TITLE
Wicket 6.x: Altered to Use Wicket Webjars for OpenLayers Resources

### DIFF
--- a/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/WicketApplication.java
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/WicketApplication.java
@@ -6,6 +6,8 @@ import org.apache.wicket.Page;
 import org.apache.wicket.RuntimeConfigurationType;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.wicketstuff.annotation.scan.AnnotatedMountScanner;
+import de.agilecoders.wicket.webjars.WicketWebjars;
+import de.agilecoders.wicket.webjars.settings.WebjarsSettings;
 
 /**
  * Provides an application that demonstrates the OpenLayers3 map.
@@ -26,9 +28,13 @@ public class WicketApplication extends WebApplication {
         // scan for annotations
         new AnnotatedMountScanner().scanPackage("org.wicketstuff.openlayers3.examples").mount(this);
 
+		// setup webjars
+		WebjarsSettings webjarsSettings = new WebjarsSettings();
+        WicketWebjars.install(this, webjarsSettings);
+
         // setup wicket boostrap
-        BootstrapSettings settings = new BootstrapSettings();
-        Bootstrap.install(this, settings);
+        BootstrapSettings bootstrapSettings = new BootstrapSettings();
+        Bootstrap.install(this, bootstrapSettings);
     }
 
     @Override

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3/pom.xml
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3/pom.xml
@@ -36,6 +36,14 @@
 
     <dependencies>
         <dependency>
+          <groupId>de.agilecoders.wicket.webjars</groupId>
+          <artifactId>wicket-webjars</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.webjars</groupId>
+          <artifactId>openlayers</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/DefaultOpenLayersMap.java
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/DefaultOpenLayersMap.java
@@ -7,6 +7,7 @@ import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.model.IModel;
 import org.wicketstuff.openlayers3.api.Map;
+import de.agilecoders.wicket.webjars.request.resource.WebjarsJavaScriptResourceReference;
 
 /**
  * Provides an OpenLayers map that fetches resources from the OpenLayers public website.
@@ -27,12 +28,12 @@ public class DefaultOpenLayersMap extends OpenLayersMap {
 
     @Override
     public void renderHead(final IHeaderResponse response) {
-        response.render(CssHeaderItem.forUrl("http://ol3js.org/en/master/css/ol.css"));
+		response.render(CssHeaderItem.forReference(new WebjarsJavaScriptResourceReference("openlayers/current/ol.css")));
 
         if (RuntimeConfigurationType.DEVELOPMENT.equals(getApplication().getConfigurationType())) {
-            response.render(JavaScriptHeaderItem.forUrl("http://ol3js.org/en/master/build/ol-debug.js"));
+			response.render(JavaScriptHeaderItem.forReference(new WebjarsJavaScriptResourceReference("openlayers/current/ol-debug.js")));
         } else {
-            response.render(JavaScriptHeaderItem.forUrl("http://ol3js.org/en/master/build/ol.js"));
+			response.render(JavaScriptHeaderItem.forReference(new WebjarsJavaScriptResourceReference("openlayers/current/ol.js")));
         }
 
         response.render(OnDomReadyHeaderItem.forScript(this.renderJs()));

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/OpenLayersMap.java
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/OpenLayersMap.java
@@ -196,7 +196,7 @@ public abstract class OpenLayersMap extends GenericPanel<Map> {
 
         // update the map
         target.appendJavaScript(JavascriptObject.JS_GLOBAL + "['map_" + getMarkupId() + "'].removeInteraction("
-			+ interaction.getJsId() + ");" + interaction.getJsId() + ".dispose();");
+			+ interaction.getJsId() + ");");
     }
 
     @Override

--- a/jdk-1.6-parent/openlayers3-parent/pom.xml
+++ b/jdk-1.6-parent/openlayers3-parent/pom.xml
@@ -2,36 +2,46 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>org.wicketstuff</groupId>
-		<artifactId>jdk-1.6-parent</artifactId>
-		<version>6.0-SNAPSHOT</version>
-	</parent>
+  <parent>
+    <groupId>org.wicketstuff</groupId>
+    <artifactId>jdk-1.6-parent</artifactId>
+    <version>6.0-SNAPSHOT</version>
+  </parent>
 
-    <artifactId>openlayers3-parent</artifactId>
-    <packaging>pom</packaging>
+  <artifactId>openlayers3-parent</artifactId>
+  <packaging>pom</packaging>
 
-    <name>Openlayers3 Integration - Parent</name>
-    <description>
-        See the child project "openlayers3" for a more complete description. This
-        is the parent for the actual project and the examples.
-    </description>
+  <name>Openlayers3 Integration - Parent</name>
+  <description>
+    See the child project "openlayers3" for a more complete description. This
+    is the parent for the actual project and the examples.
+  </description>
 
-    <modules>
-        <module>openlayers3</module>
-        <module>openlayers3-bootstrap</module>
-        <module>openlayers3-examples</module>
-    </modules>
+  <modules>
+    <module>openlayers3</module>
+    <module>openlayers3-bootstrap</module>
+    <module>openlayers3-examples</module>
+  </modules>
 
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>${project.groupId}</groupId>
-				<artifactId>wicketstuff-openlayers3</artifactId>
-				<version>${project.version}</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+	<groupId>${project.groupId}</groupId>
+	<artifactId>wicketstuff-openlayers3</artifactId>
+	<version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>de.agilecoders.wicket.webjars</groupId>
+        <artifactId>wicket-webjars</artifactId>
+        <version>0.4.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars</groupId>
+        <artifactId>openlayers</artifactId>
+        <version>3.2.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>


### PR DESCRIPTION
These are the same changes as the pull request against the master branch.

With this change the library will now use Wicket Webjars to pull in the OpenLayers 3 resources. This should resolve the issue where people set their application to HTTPS and the library continues to fetch resources via HTTP.

I also removed a call to "dispose" on interactions that causes an error when used against OpenLayers 3.3.x.