### PR TITLE
Wicket 6.x: Added Extent object, Better Click Handling, Cluster Demo Warning

### DIFF
--- a/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/ClusterPage.html
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/ClusterPage.html
@@ -9,13 +9,30 @@
 
                 <p>The clustering is done entirely by the map. All of the points in the viewable extent are loaded from
                     the data source and the clustering is performed client side. As you pan and zoom, all of the
-                    clusters are re-calculated.</p>
-
-                <p><b>Beware:</b> If you zoom out sufficiently far, you will have to wait (perhaps quite a while) for the clusters to be
-                    calculated.</p>
+                  clusters are re-calculated.</p>
 
                 <p>The data is provided by the
                     <a href="http://mhc-macris.net/">Massachusetts Historial Commisssion</a>.</p>
+
+                <h4>Beware</h4>
+                <ul>
+                  <li>If you zoom out sufficiently far, you will have to
+                    wait (perhaps quite a while) for the clusters to be
+                    calculated.</li>
+
+                  <li>There is a known issue with the OpenLayers
+                  ClusterSource, new data is only loaded from the source
+                  when map is zoomed but not panned. For now, the
+                  library has some hacky code that forces data to be
+                  loaded when the map pans. If you need this
+                  functionality, it will only work when deployed with
+                  Wicket in "development" mode, it will fail in
+                  "production". More information can be found
+                  in <a href="https://github.com/wicketstuff/core/issues/381">this
+                  Wicketstuff issue</a> and this
+                  <a href="https://groups.google.com/forum/#!topic/ol3-dev/N7TGCRax_u0">OpenLayers
+                  discussion thread</a>.</li>
+                </ul>
 
                 <div wicket:id="popover">[POPOVER]</div>
 

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/ClusterPage.java
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/ClusterPage.java
@@ -105,7 +105,7 @@ public class ClusterPage extends BasePage {
                                                 // vector data source for calculating clusters
                                                 new ServerVector(new GeoJsonFormat(),
                                                         new DefaultGeoJsonLoader(
-                                                                "http://mhc-macris.net:8080/geoserver/MHC/ows?"
+                                                                "http://mhc-macris.net:8080/geoserver/ows?"
                                                                         + "service=WFS"
                                                                         + "&version=1.0.0&request=GetFeature"
                                                                         + "&typeName=MHC:in_pts&outputFormat=json",

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/OsmPage.html
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/OsmPage.html
@@ -4,8 +4,9 @@
         <div class="row">
             <div class="col-md-12">
 
-                <p>Below is a map of the world. This map uses a OpenStreetMap to provide the image tiles. This map is
-                centered on the location of my office.</p>
+                <p>Below is a map of the world. This map uses a
+                OpenStreetMap to provide the image tiles. This is
+                displaying the state of Massachusetts.</p>
 
                 <div wicket:id="map" style="height: 600px; margin-top: 1em; border: 1px solid #a9a9a9">[MAP]</div>
 

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/OsmPage.java
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/OsmPage.java
@@ -1,17 +1,19 @@
 package org.wicketstuff.openlayers3.examples;
 
+import java.util.Arrays;
+
 import org.apache.wicket.model.Model;
 import org.wicketstuff.annotation.mount.MountPath;
 import org.wicketstuff.openlayers3.DefaultOpenLayersMap;
+import org.wicketstuff.openlayers3.api.Extent;
 import org.wicketstuff.openlayers3.api.Map;
 import org.wicketstuff.openlayers3.api.View;
+import org.wicketstuff.openlayers3.api.coordinate.Coordinate;
 import org.wicketstuff.openlayers3.api.coordinate.LongLat;
 import org.wicketstuff.openlayers3.api.layer.Layer;
 import org.wicketstuff.openlayers3.api.layer.Tile;
 import org.wicketstuff.openlayers3.api.source.Osm;
 import org.wicketstuff.openlayers3.examples.base.BasePage;
-
-import java.util.Arrays;
 
 /**
  * Provides a page with a map that uses OpenStreetMap tiles.
@@ -45,6 +47,7 @@ public class OsmPage extends BasePage {
                                 new LongLat(-72.638429, 42.313229, "EPSG:4326").transform(View.DEFAULT_PROJECTION),
 
                                 // zoom level for the view
-                                16)))));
+                                16).extent(new Extent().minimum(new LongLat(-73.574935, 42.776520, "EPSG:4326"))
+									.maximum(new LongLat(-69.754439, 41.398720, "EPSG:4326")))))));
     }
 }

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/WfsPage.java
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/WfsPage.java
@@ -103,7 +103,7 @@ public class WfsPage extends BasePage {
                                 // add our vector layer with the data
                                 vectorLayer = new Vector(new ServerVector(new GeoJsonFormat(),
                                         new DefaultGeoJsonLoader(
-                                                "http://mhc-macris.net:8080/geoserver/MHC/ows?service=WFS"
+                                                "http://mhc-macris.net:8080/geoserver/ows?service=WFS"
                                                         + "&version=1.0.0&request=GetFeature&typeName=MHC:in_pts"
                                                         + "&outputFormat=json",
                                                 "EPSG:3857"),

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/WicketApplication.java
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3-examples/src/main/java/org/wicketstuff/openlayers3/examples/WicketApplication.java
@@ -28,8 +28,8 @@ public class WicketApplication extends WebApplication {
         // scan for annotations
         new AnnotatedMountScanner().scanPackage("org.wicketstuff.openlayers3.examples").mount(this);
 
-		// setup webjars
-		WebjarsSettings webjarsSettings = new WebjarsSettings();
+	// setup webjars
+	WebjarsSettings webjarsSettings = new WebjarsSettings();
         WicketWebjars.install(this, webjarsSettings);
 
         // setup wicket boostrap

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/OpenLayersMap.java
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/OpenLayersMap.java
@@ -8,6 +8,7 @@ import org.apache.wicket.markup.html.panel.GenericPanel;
 import org.apache.wicket.model.IModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wicketstuff.openlayers3.api.Extent;
 import org.wicketstuff.openlayers3.api.Feature;
 import org.wicketstuff.openlayers3.api.JavascriptObject;
 import org.wicketstuff.openlayers3.api.Map;
@@ -199,6 +200,18 @@ public abstract class OpenLayersMap extends GenericPanel<Map> {
 			+ interaction.getJsId() + ");");
     }
 
+	/**
+     * Sets the extent for the map and zooms to that extent.
+     *
+     * @param target Ajax request target
+     * @param extent Extent to which the map will be zoomed
+     */
+	public void zoomToExtent(AjaxRequestTarget target, Extent extent) {
+		target.appendJavaScript(JavascriptObject.JS_GLOBAL + "['map_" + getMarkupId() + "'].getView().fitExtent("
+			+ getModelObject().getView().getExtent().renderJsForView(getModelObject().getView()) + ","
+			+ JavascriptObject.JS_GLOBAL + "['map_" + getMarkupId() + "']" + ".getSize());");
+	}
+
     @Override
     public abstract void renderHead(final IHeaderResponse response);
 
@@ -346,6 +359,11 @@ public abstract class OpenLayersMap extends GenericPanel<Map> {
                 }
             }
         }
+
+		if(map.getView().getExtent() != null) {
+			builder.append(map.getJsId() + ".getView().fitExtent(" + map.getView().getExtent().renderJsForView(map.getView()) + ","
+				+ map.getJsId() + ".getSize());");
+		}
 
         return builder.toString();
     }

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/api/Extent.java
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/api/Extent.java
@@ -1,0 +1,106 @@
+package org.wicketstuff.openlayers3.api;
+
+import java.io.Serializable;
+
+import org.wicketstuff.openlayers3.api.coordinate.LongLat;
+
+/**
+ * Provides an object that models an extent, or selection of a map.
+ */
+public class Extent extends JavascriptObject implements Serializable {
+
+	/**
+	 * The maximum coordinate for this extent.
+	 */
+	private LongLat maximum;
+
+	/**
+	 * The minimum coordinate for this extent.
+	 */
+	private LongLat minimum;
+
+	/**
+	 * Returns the extent minimum coordinate.
+	 *
+	 * @return Coordinate with the minimum
+	 */
+	public LongLat getMinimum() {
+		return minimum;
+	}
+
+	/**
+	 * Sets the extent minimum coordinate.
+	 *
+	 * @param minimum The minimum coordinate
+	 */
+	public void setMinimum(LongLat minimum) {
+		this.minimum = minimum;
+	}
+
+	/**
+	 * Sets the extent minimum coordinate.
+	 *
+	 * @param minimum The minimum coordinate
+	 * @return this instance
+	 */
+	public Extent minimum(LongLat minimum) {
+		setMinimum(minimum);
+		return this;
+	}
+
+	/**
+	 * Returns the maximum coodinate.
+	 *
+	 * @return The coordinate with the maximum
+	 */
+	public LongLat getMaximum() {
+		return maximum;
+	}
+
+	/**
+	 * Sets the maximum coodinate.
+	 *
+	 * @param maximum The maximum coordinate
+	 */
+	public void setMaximum(LongLat maximum) {
+		this.maximum = maximum;
+	}
+
+	/**
+	 * Sets the maximum coodinate.
+	 *
+	 * @param maximum The maximum coordinate
+	 * @return this instance
+	 */
+	public Extent maximum(LongLat maximum) {
+		setMaximum(maximum);
+		return this;
+	}
+
+	public String renderJsForView(View view) {
+
+		StringBuilder builder = new StringBuilder();
+		builder.append("ol.extent.boundingExtent([");
+		builder.append(getMinimum().transform(view.getProjection()).renderJs());
+		builder.append(",");
+		builder.append(getMaximum().transform(view.getProjection()).renderJs());
+		builder.append("])");
+		return builder.toString();
+	}
+
+	@Override
+    public String getJsType() {
+        return "ol.Extent";
+    }
+
+    @Override
+    public String renderJs() {
+
+        StringBuilder builder = new StringBuilder();
+		builder.append("[");
+		builder.append(getMinimum().getX() + "," + getMinimum().getY() + ",");
+		builder.append(getMaximum().getX() + "," + getMaximum().getY());
+		builder.append("]");
+		return builder.toString();
+	}
+}

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/api/View.java
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/api/View.java
@@ -39,6 +39,11 @@ public class View extends JavascriptObject implements Serializable {
      */
     public String projection;
 
+	/**
+	 * Extent for this map.
+	 */
+	private Extent extent;
+
     /**
      * Creates a new instance.
      *
@@ -92,12 +97,31 @@ public class View extends JavascriptObject implements Serializable {
      *         The projection for this view
      */
     public View(Coordinate center, Integer zoom, Integer maxZoom, String projection) {
+		this(center, zoom, maxZoom, projection, null);
+    }
+
+	/**
+     * Creates a new instance.
+     *
+     * @param center
+     *         The coordinate at the center of this view
+     * @param zoom
+     *         The zoom factor for this view
+     * @param maxZoom
+     *         The maximum zoom factor for this view
+     * @param projection
+     *         The projection for this view
+     * @param extent
+     *         The extent for this view
+     */
+    public View(Coordinate center, Integer zoom, Integer maxZoom, String projection, Extent extent) {
         super();
 
         this.center = center;
         this.zoom = zoom;
         this.maxZoom = maxZoom;
         this.projection = projection;
+		this.extent = extent;
     }
 
     /**
@@ -254,6 +278,35 @@ public class View extends JavascriptObject implements Serializable {
         setMaxZoom(maxZoom);
         return this;
     }
+
+	/**
+	 * Returns the extent for this view.
+	 *
+	 * @return Extent for this view
+	 */
+	public Extent getExtent() {
+		return extent;
+	}
+
+	/**
+	 * Sets the extent for this view.
+	 *
+	 * @param extent The extent for this view
+	 */
+	public void setExtent(Extent extent) {
+		this.extent = extent;
+	}
+
+	/**
+	 * Sets the extent for this view.
+	 *
+	 * @param extent The extent for this view
+	 * @return this instance
+	 */
+	public View extent(Extent extent) {
+		setExtent(extent);
+		return this;
+	}
 
     @Override
     public String getJsType() {

--- a/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/behavior/ClickHandler.js
+++ b/jdk-1.6-parent/openlayers3-parent/openlayers3/src/main/java/org/wicketstuff/openlayers3/behavior/ClickHandler.js
@@ -6,7 +6,7 @@ var clickHandler_${componentId}_${clickHandlerId} = function(coordinate) {
          }]});
 };
 
-window.org_wicketstuff_openlayers3['map_${componentId}'].on('click', function(event) {
+window.org_wicketstuff_openlayers3['map_${componentId}'].on('singleclick', function(event) {
     var coordinateRaw = event.coordinate;
 
     var coordinateHdms = coordinateRaw;


### PR DESCRIPTION
I coded up an Extent object that may be used to specify an area (a minimum coordinate and a maximum). This extent can then be used to instruct the map on what needs to be in the viewable area; the map will make a best effort to zoom to a level that includes the full extent.

I altered the map to correctly handle single clicks (double clicks are handled by OpenLayers).

I added a warning to the cluster demo page that indicates the issue with the cluster data source and panning of the map.