### PR TITLE
add from/bind shortcut

### DIFF
--- a/jdk-1.7-parent/wicketstuff-lazymodel/src/main/java/org/wicketstuff/lazymodel/LazyModel.java
+++ b/jdk-1.7-parent/wicketstuff-lazymodel/src/main/java/org/wicketstuff/lazymodel/LazyModel.java
@@ -556,6 +556,19 @@ public class LazyModel<T> implements IModel<T>, IObjectClassAwareModel<T>,
 	}
 
 	/**
+	 * Shortcut for {@link #from(Class)} and {@link #bind(Object)}. Use this for quick model building on top of a
+	 * type-erased model.
+	 *
+	 * @param target The model to bind to.
+	 * @param type The type parameter for that model.
+	 * @param <T>
+	 * @return a result proxy for further evaluation.
+	 */
+	public static <T> T from(IModel<T> target, Class<T> type) {
+		return (T) new BoundEvaluation<T>(type, target).proxy();
+	}
+
+	/**
 	 * Start a lazy evaluation.
 	 * 
 	 * @param target

--- a/jdk-1.7-parent/wicketstuff-lazymodel/src/test/java/org/wicketstuff/lazymodel/LazyModelTest.java
+++ b/jdk-1.7-parent/wicketstuff-lazymodel/src/test/java/org/wicketstuff/lazymodel/LazyModelTest.java
@@ -880,6 +880,21 @@ public class LazyModelTest {
 	}
 
 	@Test
+	public void fromTypeErasedModelWithClass() throws Exception
+	{
+		final A a = new A();
+		a.b = new B();
+
+		Model target = new Model(a);
+		LazyModel<B> model = model(from(target, A.class).getB());
+
+		assertEquals(B.class, model.getObjectClass());
+		assertEquals("b", model.getPath());
+		assertEquals(a.b, model.getObject());
+	}
+
+
+	@Test
 	public void bindToTypeErasedModelWithNull() {
 		LazyModel<B> model = model(from(A.class).getB()).bind(
 				new Model<A>(null));


### PR DESCRIPTION
When dealing with normal IModel<T> instances, the model object type is usually erased and so LazyModel cannot determine it at runtime. To deal with that, one needs to first build the model over a Class<T> and then call bind on it. This is rather verbose and not particularly readable.

This pull request adds an overloaded method from(IModel<T> target, Class<T> type) to shorten this a bit.