### PR TITLE
reflect type from modelobject

### DIFF
--- a/jdk-1.7-parent/wicketstuff-lazymodel/src/main/java/org/wicketstuff/lazymodel/LazyModel.java
+++ b/jdk-1.7-parent/wicketstuff-lazymodel/src/main/java/org/wicketstuff/lazymodel/LazyModel.java
@@ -556,6 +556,19 @@ public class LazyModel<T> implements IModel<T>, IObjectClassAwareModel<T>,
 	}
 
 	/**
+	 * Shortcut for {@link #from(Class)} and {@link #bind(Object)}. Use this for quick model building on top of a
+	 * type-erased model.
+	 *
+	 * @param target The model to bind to.
+	 * @param type The type parameter for that model.
+	 * @param <T>
+	 * @return a result proxy for further evaluation.
+	 */
+	public static <T> T from(IModel<T> target, Class<T> type) {
+		return (T) new BoundEvaluation<T>(type, target).proxy();
+	}
+
+	/**
 	 * Start a lazy evaluation.
 	 * 
 	 * @param target

--- a/jdk-1.7-parent/wicketstuff-lazymodel/src/main/java/org/wicketstuff/lazymodel/LazyModel.java
+++ b/jdk-1.7-parent/wicketstuff-lazymodel/src/main/java/org/wicketstuff/lazymodel/LazyModel.java
@@ -563,9 +563,23 @@ public class LazyModel<T> implements IModel<T>, IObjectClassAwareModel<T>,
 	 * @param type The type parameter for that model.
 	 * @param <T>
 	 * @return a result proxy for further evaluation.
+	 * @see #fromObject(IModel)
 	 */
 	public static <T> T from(IModel<T> target, Class<T> type) {
 		return (T) new BoundEvaluation<T>(type, target).proxy();
+	}
+
+	/**
+	 * Start a lazy evaluation, using the reflected runtime type of the given model's object. Use this for terse model
+	 * building on top of a type erased model.
+	 * @param target The model to bind to.
+	 * @param <T>
+	 * @return a result proxy for further evaluation.
+	 * @see #from(IModel, Class)
+	 */
+	public static <T> T fromObject(IModel<T> target)
+	{
+		return (T) new BoundEvaluation<T>(target.getObject().getClass(), target).proxy();
 	}
 
 	/**

--- a/jdk-1.7-parent/wicketstuff-lazymodel/src/test/java/org/wicketstuff/lazymodel/LazyModelTest.java
+++ b/jdk-1.7-parent/wicketstuff-lazymodel/src/test/java/org/wicketstuff/lazymodel/LazyModelTest.java
@@ -880,6 +880,21 @@ public class LazyModelTest {
 	}
 
 	@Test
+	public void fromTypeErasedModelWithClass() throws Exception
+	{
+		final A a = new A();
+		a.b = new B();
+
+		Model target = new Model(a);
+		LazyModel<B> model = model(from(target, A.class).getB());
+
+		assertEquals(B.class, model.getObjectClass());
+		assertEquals("b", model.getPath());
+		assertEquals(a.b, model.getObject());
+	}
+
+
+	@Test
 	public void bindToTypeErasedModelWithNull() {
 		LazyModel<B> model = model(from(A.class).getB()).bind(
 				new Model<A>(null));

--- a/jdk-1.7-parent/wicketstuff-lazymodel/src/test/java/org/wicketstuff/lazymodel/LazyModelTest.java
+++ b/jdk-1.7-parent/wicketstuff-lazymodel/src/test/java/org/wicketstuff/lazymodel/LazyModelTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.wicketstuff.lazymodel.LazyModel.from;
+import static org.wicketstuff.lazymodel.LazyModel.fromObject;
 import static org.wicketstuff.lazymodel.LazyModel.model;
 import static org.wicketstuff.lazymodel.LazyModel.path;
 
@@ -893,6 +894,19 @@ public class LazyModelTest {
 		assertEquals(a.b, model.getObject());
 	}
 
+	@Test
+	public void fromTypeErasedModelWithReflectionOnObject() throws Exception
+	{
+		final A a = new A();
+		a.b = new B();
+
+		Model<A> target = new Model(a);
+		LazyModel<B> model = model(fromObject(target).getB());
+
+		assertEquals(B.class, model.getObjectClass());
+		assertEquals("b", model.getPath());
+		assertEquals(a.b, model.getObject());
+	}
 
 	@Test
 	public void bindToTypeErasedModelWithNull() {


### PR DESCRIPTION
Building on my other pull request (#415), this adds a separate from method named fromObject(IModel<T>) that uses target.getObject().getClass() to determine the target type. This is useful for the (pretty common) case of models with an erased type parameter. I'm using a separate method rather than doing this in from(IModel<T>) to not change existing behavior and to avoid calling methods on the target when the user does not expect it.