### PR TITLE
Fixed attribute in LoginButton constructor to get facebook permissions to work correctly.

### DIFF
--- a/jdk-1.7-parent/wicket-facebook-parent/wicket-facebook/src/main/java/org/wicketstuff/facebook/plugins/LoginButton.java
+++ b/jdk-1.7-parent/wicket-facebook-parent/wicket-facebook/src/main/java/org/wicketstuff/facebook/plugins/LoginButton.java
@@ -60,7 +60,7 @@ public class LoginButton extends AbstractFacebookPlugin
 
 		add(new AttributeModifier("data-show-faces", new PropertyModel<Boolean>(this, "showFaces")));
 		add(new AttributeModifier("data-max-rows", new PropertyModel<Boolean>(this, "maxRows")));
-		add(new AttributeModifier("data-perms", new PermissionsModel()));
+		add(new AttributeModifier("data-scope", new PermissionsModel()));
 	}
 
 	/**


### PR DESCRIPTION
I just started using the wicket facebook stuff, and found that it works when requesting default permissions, but when I add additional permissions they never seem to get added. After a bit of reading, I saw a comment that said they changed it from data-perms to data-scope. So I changed that and it seems to work for me now. 