### PR TITLE
removed unused logging dependencies

### DIFF
--- a/urlfragment-parent/urlfragment/pom.xml
+++ b/urlfragment-parent/urlfragment/pom.xml
@@ -42,15 +42,6 @@
 			<artifactId>wicket-core</artifactId>
 			<version>${wicket.version}</version>
 		</dependency>
-		<!-- LOGGING DEPENDENCIES - LOG4J -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-		</dependency>
 		<!--  JUNIT DEPENDENCY FOR TESTING -->
 		<dependency>
 			<groupId>junit</groupId>


### PR DESCRIPTION
causes a log4j dependency that messes up your slf4j logging setup