### PR TITLE
Should not share userProvidedResourceReferences between instances

### DIFF
--- a/jwicket-parent/jwicket-core/src/main/java/org/wicketstuff/jwicket/JQueryAjaxBehavior.java
+++ b/jwicket-parent/jwicket-core/src/main/java/org/wicketstuff/jwicket/JQueryAjaxBehavior.java
@@ -209,13 +209,13 @@ public abstract class JQueryAjaxBehavior extends AbstractDefaultAjaxBehavior {
 		}
 	}
 
-    private static final List<JavaScriptResourceReference> userProvidedResourceReferences = new ArrayList<JavaScriptResourceReference>();
+    private final List<JavaScriptResourceReference> userProvidedResourceReferences = new ArrayList<JavaScriptResourceReference>();
 
-	public static void addUserProvidedResourceReferences(final JavaScriptResourceReference... resources) {
+	public void addUserProvidedResourceReferences(final JavaScriptResourceReference... resources) {
 		userProvidedResourceReferences.addAll(Arrays.asList(resources));
 	}
 
-	public static List<JavaScriptResourceReference> getUserProvidedResourceReferences() {
+	public List<JavaScriptResourceReference> getUserProvidedResourceReferences() {
 		return userProvidedResourceReferences;
 	}
 

--- a/jwicket-parent/jwicket-examples/src/main/java/org/wicketstuff/jwicket/demo/tooltip/JQueryUiTooltipPage.java
+++ b/jwicket-parent/jwicket-examples/src/main/java/org/wicketstuff/jwicket/demo/tooltip/JQueryUiTooltipPage.java
@@ -46,7 +46,6 @@ public class JQueryUiTooltipPage extends WebPage
 		super();
 
 		// jQuery 1.6+ required for the jQueryUi tooltip widget
-		JQueryUiTooltip.addUserProvidedResourceReferences(JQueryResourceReference.get());
 
 		Component individualTooltip = new WebMarkupContainer("individualTooltip");
 		individualTooltip.add(tooltip_1_10_3() /**/

--- a/jwicket-parent/jwicket-ui/jwicket-ui-tooltip/src/test/java/org/wicketstuff/jwicket/ui/tooltip/TestJQueryUiTooltip.java
+++ b/jwicket-parent/jwicket-ui/jwicket-ui-tooltip/src/test/java/org/wicketstuff/jwicket/ui/tooltip/TestJQueryUiTooltip.java
@@ -21,16 +21,22 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.head.CssReferenceHeaderItem;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.request.resource.CssResourceReference;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
 import org.apache.wicket.util.tester.WicketTester;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.wicketstuff.jwicket.JsOption;
+
 
 /**
  * 
@@ -295,6 +301,19 @@ public class TestJQueryUiTooltip
 		tooltip.renderHead(component, response);
 
 		verify(widget).buildJS("'#" + component.getMarkupId() + "'");
+	}
+
+	@Test
+	public void shouldNotShareUserProvidedResourceReferencesBetweenInstances() {
+		JQueryUiTooltip tooltip1 = JQueryUiTooltip.tooltip_1_10_3();
+		List<JavaScriptResourceReference> resourceReferencesAfter1 = new ArrayList<>(
+				tooltip1.getUserProvidedResourceReferences());
+
+		JQueryUiTooltip tooltip2 = JQueryUiTooltip.tooltip_1_10_3();
+		List<JavaScriptResourceReference> resourceReferencesAfter2 = new ArrayList<>(
+				tooltip2.getUserProvidedResourceReferences());
+		
+		Assert.assertEquals(resourceReferencesAfter1, resourceReferencesAfter2);
 	}
 
 }


### PR DESCRIPTION
JQueryAjaxBehavior has a static [userProvidedResourceReferences](https://github.com/wicketstuff/core/blob/master/jwicket-parent/jwicket-core/src/main/java/org/wicketstuff/jwicket/JQueryAjaxBehavior.java#L212), which causes problems:
- [Every time a JQueryUiTooltip is instantiated](https://github.com/wicketstuff/core/blob/master/jwicket-parent/jwicket-ui/jwicket-ui-tooltip/src/main/java/org/wicketstuff/jwicket/ui/tooltip/JQueryUiTooltip.java#L104) a JQueryResourceReference.get() instance is added (memory consumption increases)
- Adding elements to the static member is not thread safe. Instantiating JQueryUiTooltips concurrently results in a 'null' references in the list. Having one 'null' references leads to an assertion [while rendering the behavior](https://github.com/wicketstuff/core/blob/master/jwicket-parent/jwicket-core/src/main/java/org/wicketstuff/jwicket/JQueryAjaxBehavior.java#L186) (with an application restart as only 'solution').

I do not know the reason for this decision? Please have a look. This request is based on the master, but we're still on version 6. Please apply this fix also on the other branches, or let me know when I can help.