### PR TITLE
Fix usage of diamond operator in wicket 6

### DIFF
--- a/jwicket-parent/jwicket-ui/jwicket-ui-tooltip/src/test/java/org/wicketstuff/jwicket/ui/tooltip/TestJQueryUiTooltip.java
+++ b/jwicket-parent/jwicket-ui/jwicket-ui-tooltip/src/test/java/org/wicketstuff/jwicket/ui/tooltip/TestJQueryUiTooltip.java
@@ -306,11 +306,11 @@ public class TestJQueryUiTooltip
 	@Test
 	public void shouldNotShareUserProvidedResourceReferencesBetweenInstances() {
 		JQueryUiTooltip tooltip1 = JQueryUiTooltip.tooltip_1_10_3();
-		List<JavaScriptResourceReference> resourceReferencesAfter1 = new ArrayList<>(
+		List<JavaScriptResourceReference> resourceReferencesAfter1 = new ArrayList<JavaScriptResourceReference>(
 				tooltip1.getUserProvidedResourceReferences());
 
 		JQueryUiTooltip tooltip2 = JQueryUiTooltip.tooltip_1_10_3();
-		List<JavaScriptResourceReference> resourceReferencesAfter2 = new ArrayList<>(
+		List<JavaScriptResourceReference> resourceReferencesAfter2 = new ArrayList<JavaScriptResourceReference>(
 				tooltip2.getUserProvidedResourceReferences());
 		
 		Assert.assertEquals(resourceReferencesAfter1, resourceReferencesAfter2);


### PR DESCRIPTION
The port to wicket-6.x of https://github.com/wicketstuff/core/pull/441 doesn't work. The diamond operator cannot be used in Java 6.