### PR TITLE
Osgi bundle support for input-events, tinymce4, and restannotations projects

### DIFF
--- a/input-events-parent/input-events/pom.xml
+++ b/input-events-parent/input-events/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<artifactId>wicketstuff-input-events</artifactId>
-	<packaging>jar</packaging>
+	<packaging>bundle</packaging>
 
 	<name>Input Events</name>
 	<description>

--- a/pom.xml
+++ b/pom.xml
@@ -918,6 +918,13 @@
 					</toolchains>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.5.3</version>
+				<inherited>true</inherited>
+				<extensions>true</extensions>
+			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -922,6 +922,44 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>org.apache.maven.plugins</groupId>
+										<artifactId>maven-toolchains-plugin</artifactId>
+										<versionRange>[1.0,)</versionRange>
+										<goals>
+											<goal>toolchain</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore>true</ignore>
+									</action>
+								</pluginExecution>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>net.alchim31.maven</groupId>
+										<artifactId>scala-maven-plugin</artifactId>
+										<versionRange>[3.2.2,)</versionRange>
+										<goals>
+											<goal>compile</goal>
+											<goal>testCompile</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore>true</ignore>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-source-plugin</artifactId>
 					<version>2.4</version>

--- a/tinymce4-parent/tinymce4/pom.xml
+++ b/tinymce4-parent/tinymce4/pom.xml
@@ -21,7 +21,7 @@
 	</parent>
 
 	<artifactId>wicketstuff-tinymce4</artifactId>
-	<packaging>jar</packaging>
+	<packaging>bundle</packaging>
 
 	<name>TinyMCE4</name>
 	<description>

--- a/wicketstuff-restannotations-parent/restannotations-json/pom.xml
+++ b/wicketstuff-restannotations-parent/restannotations-json/pom.xml
@@ -21,7 +21,7 @@
 	</parent>
 
 	<artifactId>wicketstuff-restannotations-json</artifactId>
-	<packaging>jar</packaging>
+	<packaging>bundle</packaging>
 
 	<name>wicketstuff-restannotations-json</name>
 

--- a/wicketstuff-restannotations-parent/restannotations/pom.xml
+++ b/wicketstuff-restannotations-parent/restannotations/pom.xml
@@ -21,7 +21,7 @@
 	</parent>
 
 	<artifactId>wicketstuff-restannotations</artifactId>
-	<packaging>jar</packaging>
+	<packaging>bundle</packaging>
 
 	<name>wicketstuff-restannotations</name>
 


### PR DESCRIPTION
Updated maven packaging type from 'jar' to 'bundle' for below given projects.
1. Input-events
2. tinymce4
3. restannotations & restannotations-json