### PR TITLE
Release 7.1.0

### DIFF
--- a/annotation/pom.xml
+++ b/annotation/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-annotation</artifactId>

--- a/annotationeventdispatcher-parent/annotationeventdispatcher/pom.xml
+++ b/annotationeventdispatcher-parent/annotationeventdispatcher/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-annotationeventdispatcher-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-annotationeventdispatcher</artifactId>

--- a/annotationeventdispatcher-parent/pom.xml
+++ b/annotationeventdispatcher-parent/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-annotationeventdispatcher-parent</artifactId>
 	<name>Annotation Event Dispatcher - Parent</name>

--- a/async-tasks-parent/async-tasks-demo/pom.xml
+++ b/async-tasks-parent/async-tasks-demo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>async-tasks-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>async-task-demo</artifactId>

--- a/async-tasks-parent/async-tasks-impl/pom.xml
+++ b/async-tasks-parent/async-tasks-impl/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>async-tasks-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>async-task-impl</artifactId>

--- a/async-tasks-parent/pom.xml
+++ b/async-tasks-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>async-tasks-parent</artifactId>

--- a/autocomplete-tagit-parent/autocomplete-tagit-examples/pom.xml
+++ b/autocomplete-tagit-parent/autocomplete-tagit-examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-autocomplete-tagit-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-autocomplete-tagit-examples</artifactId>

--- a/autocomplete-tagit-parent/autocomplete-tagit/pom.xml
+++ b/autocomplete-tagit-parent/autocomplete-tagit/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-autocomplete-tagit-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-autocomplete-tagit</artifactId>

--- a/autocomplete-tagit-parent/pom.xml
+++ b/autocomplete-tagit-parent/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-autocomplete-tagit-parent</artifactId>
 	<name>Autocomplete Tag It Parent</name>

--- a/browserid-parent/browserid-examples/pom.xml
+++ b/browserid-parent/browserid-examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-browserid-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-browserid-examples</artifactId>

--- a/browserid-parent/browserid/pom.xml
+++ b/browserid-parent/browserid/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-browserid-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-browserid</artifactId>

--- a/browserid-parent/pom.xml
+++ b/browserid-parent/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-browserid-parent</artifactId>
 	<name>BrowserId Parent</name>

--- a/closure-compiler/pom.xml
+++ b/closure-compiler/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.wicketstuff</groupId>
     <artifactId>wicketstuff-core</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
   </parent>
 
   <artifactId>wicketstuff-closure-compiler</artifactId>

--- a/datastores-parent/datastore-cassandra/pom.xml
+++ b/datastores-parent/datastore-cassandra/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>datastores-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/datastores-parent/datastore-common/pom.xml
+++ b/datastores-parent/datastore-common/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>datastores-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/datastores-parent/datastore-hazelcast/pom.xml
+++ b/datastores-parent/datastore-hazelcast/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>datastores-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/datastores-parent/datastore-memcached/pom.xml
+++ b/datastores-parent/datastore-memcached/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>datastores-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/datastores-parent/datastore-redis/pom.xml
+++ b/datastores-parent/datastore-redis/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>datastores-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/datastores-parent/pom.xml
+++ b/datastores-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>datastores-parent</artifactId>

--- a/datatables-parent/datatables-examples/pom.xml
+++ b/datatables-parent/datatables-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>datatables-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>datatables-examples</artifactId>

--- a/datatables-parent/datatables/pom.xml
+++ b/datatables-parent/datatables/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>datatables-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-datatables</artifactId>

--- a/datatables-parent/pom.xml
+++ b/datatables-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>datatables-parent</artifactId>

--- a/editable-grid-parent/editable-grid-examples/pom.xml
+++ b/editable-grid-parent/editable-grid-examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>editable-grid-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>editable-grid-examples</artifactId>
 	<packaging>war</packaging>

--- a/editable-grid-parent/editable-grid/pom.xml
+++ b/editable-grid-parent/editable-grid/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>editable-grid-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-editable-grid</artifactId>
 	<name>Editable Grid component for Apache Wicket</name>

--- a/editable-grid-parent/pom.xml
+++ b/editable-grid-parent/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>editable-grid-parent</artifactId>

--- a/flot-parent/flot-examples/pom.xml
+++ b/flot-parent/flot-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>flot-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>flot-examples</artifactId>

--- a/flot-parent/flot/pom.xml
+++ b/flot-parent/flot/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>flot-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-flot</artifactId>

--- a/flot-parent/pom.xml
+++ b/flot-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>flot-parent</artifactId>

--- a/gae-initializer-parent/gae-initializer-example/pom.xml
+++ b/gae-initializer-parent/gae-initializer-example/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>gae-initializer-parent</artifactId>
     <groupId>org.wicketstuff</groupId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
   </parent>
 
   <artifactId>gae-initializer-example</artifactId>

--- a/gae-initializer-parent/gae-initializer/pom.xml
+++ b/gae-initializer-parent/gae-initializer/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>gae-initializer-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-gae-initializer</artifactId>

--- a/gae-initializer-parent/pom.xml
+++ b/gae-initializer-parent/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 	
     <artifactId>gae-initializer-parent</artifactId>

--- a/gmap3-parent/gmap3-examples/pom.xml
+++ b/gmap3-parent/gmap3-examples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>gmap3-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-gmap3-examples</artifactId>

--- a/gmap3-parent/gmap3/pom.xml
+++ b/gmap3-parent/gmap3/pom.xml
@@ -21,7 +21,7 @@ limitations under the License.
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>gmap3-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-gmap3</artifactId>

--- a/gmap3-parent/pom.xml
+++ b/gmap3-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>gmap3-parent</artifactId>

--- a/googlecharts-parent/googlecharts-examples/pom.xml
+++ b/googlecharts-parent/googlecharts-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>googlecharts-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>googlecharts-examples</artifactId>

--- a/googlecharts-parent/googlecharts/pom.xml
+++ b/googlecharts-parent/googlecharts/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>googlecharts-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
     <artifactId>wicketstuff-googlecharts</artifactId>
     <packaging>jar</packaging>

--- a/googlecharts-parent/pom.xml
+++ b/googlecharts-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>googlecharts-parent</artifactId>

--- a/htmlcompressor-parent/htmlcompressor-examples/pom.xml
+++ b/htmlcompressor-parent/htmlcompressor-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-htmlcompressor-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-htmlcompressor-examples</artifactId>

--- a/htmlcompressor-parent/htmlcompressor/pom.xml
+++ b/htmlcompressor-parent/htmlcompressor/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-htmlcompressor-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-htmlcompressor</artifactId>

--- a/htmlcompressor-parent/pom.xml
+++ b/htmlcompressor-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-htmlcompressor-parent</artifactId>

--- a/inmethod-grid-parent/inmethod-grid-examples/pom.xml
+++ b/inmethod-grid-parent/inmethod-grid-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>inmethod-grid-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-inmethod-grid-examples</artifactId>

--- a/inmethod-grid-parent/inmethod-grid/pom.xml
+++ b/inmethod-grid-parent/inmethod-grid/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>inmethod-grid-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-inmethod-grid</artifactId>

--- a/inmethod-grid-parent/pom.xml
+++ b/inmethod-grid-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>inmethod-grid-parent</artifactId>

--- a/input-events-parent/input-events-examples/pom.xml
+++ b/input-events-parent/input-events-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>input-events-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>input-events-examples</artifactId>

--- a/input-events-parent/input-events/pom.xml
+++ b/input-events-parent/input-events/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>input-events-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-input-events</artifactId>

--- a/input-events-parent/pom.xml
+++ b/input-events-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>input-events-parent</artifactId>

--- a/jasperreports-parent/jasperreports-examples/pom.xml
+++ b/jasperreports-parent/jasperreports-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>jasperreports-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>jasperreports-examples</artifactId>

--- a/jasperreports-parent/jasperreports/pom.xml
+++ b/jasperreports-parent/jasperreports/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>jasperreports-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-jasperreports</artifactId>

--- a/jasperreports-parent/pom.xml
+++ b/jasperreports-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>jasperreports-parent</artifactId>

--- a/javaee-inject-parent/javaee-inject-examples/javaee-inject-example-ear/pom.xml
+++ b/javaee-inject-parent/javaee-inject-examples/javaee-inject-example-ear/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>javaee-inject-examples</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
     <artifactId>javaee-inject-example-ear</artifactId>
     <packaging>ear</packaging>

--- a/javaee-inject-parent/javaee-inject-examples/javaee-inject-example-ejb/pom.xml
+++ b/javaee-inject-parent/javaee-inject-examples/javaee-inject-example-ejb/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>javaee-inject-examples</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>javaee-inject-example-ejb</artifactId>
 	<packaging>ejb</packaging>

--- a/javaee-inject-parent/javaee-inject-examples/javaee-inject-example-war/pom.xml
+++ b/javaee-inject-parent/javaee-inject-examples/javaee-inject-example-war/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>javaee-inject-examples</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
     <artifactId>javaee-inject-example-war</artifactId>
     <packaging>war</packaging>

--- a/javaee-inject-parent/javaee-inject-examples/pom.xml
+++ b/javaee-inject-parent/javaee-inject-examples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>javaee-inject-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>javaee-inject-examples</artifactId>
 	<packaging>pom</packaging>

--- a/javaee-inject-parent/javaee-inject/pom.xml
+++ b/javaee-inject-parent/javaee-inject/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>javaee-inject-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
     <artifactId>wicketstuff-javaee-inject</artifactId>
     <packaging>jar</packaging>

--- a/javaee-inject-parent/pom.xml
+++ b/javaee-inject-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
     <artifactId>javaee-inject-parent</artifactId>
     <packaging>pom</packaging>

--- a/jee-web-parent/jee-web-examples/pom.xml
+++ b/jee-web-parent/jee-web-examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>jee-web-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-jee-web-examples</artifactId>
 	<packaging>war</packaging>

--- a/jee-web-parent/jee-web/pom.xml
+++ b/jee-web-parent/jee-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>jee-web-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 	<artifactId>wicketstuff-jee-web</artifactId>
 	<packaging>jar</packaging>

--- a/jee-web-parent/pom.xml
+++ b/jee-web-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 	<artifactId>jee-web-parent</artifactId>
 	<packaging>pom</packaging>

--- a/jqplot-parent/jqplot-examples/pom.xml
+++ b/jqplot-parent/jqplot-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>jqplot-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>jqplot-examples</artifactId>

--- a/jqplot-parent/jqplot/pom.xml
+++ b/jqplot-parent/jqplot/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>jqplot-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>jqplot</artifactId>

--- a/jqplot-parent/pom.xml
+++ b/jqplot-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>jqplot-parent</artifactId>

--- a/jquery-parent/jquery-examples/pom.xml
+++ b/jquery-parent/jquery-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>jquery-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>jquery-examples</artifactId>

--- a/jquery-parent/jquery/pom.xml
+++ b/jquery-parent/jquery/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>jquery-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-jquery</artifactId>

--- a/jquery-parent/pom.xml
+++ b/jquery-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>jquery-parent</artifactId>

--- a/jwicket-parent/dropdown-menu/pom.xml
+++ b/jwicket-parent/dropdown-menu/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-jwicket-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jwicket-parent/jwicket-core/pom.xml
+++ b/jwicket-parent/jwicket-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-jwicket-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jwicket-parent/jwicket-examples/pom.xml
+++ b/jwicket-parent/jwicket-examples/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-jwicket-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-jwicket-examples</artifactId>

--- a/jwicket-parent/jwicket-tooltip/jwicket-tooltip-beautytips/pom.xml
+++ b/jwicket-parent/jwicket-tooltip/jwicket-tooltip-beautytips/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-jwicket-tooltip</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jwicket-parent/jwicket-tooltip/jwicket-tooltip-walterzorn/pom.xml
+++ b/jwicket-parent/jwicket-tooltip/jwicket-tooltip-walterzorn/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-jwicket-tooltip</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jwicket-parent/jwicket-tooltip/jwicket-tooltip-wtooltips/pom.xml
+++ b/jwicket-parent/jwicket-tooltip/jwicket-tooltip-wtooltips/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-jwicket-tooltip</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jwicket-parent/jwicket-tooltip/pom.xml
+++ b/jwicket-parent/jwicket-tooltip/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-jwicket-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 	

--- a/jwicket-parent/jwicket-ui/jwicket-ui-accordion/pom.xml
+++ b/jwicket-parent/jwicket-ui/jwicket-ui-accordion/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-jwicket-ui</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jwicket-parent/jwicket-ui/jwicket-ui-datepicker/pom.xml
+++ b/jwicket-parent/jwicket-ui/jwicket-ui-datepicker/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-jwicket-ui</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jwicket-parent/jwicket-ui/jwicket-ui-dragdrop/pom.xml
+++ b/jwicket-parent/jwicket-ui/jwicket-ui-dragdrop/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-jwicket-ui</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jwicket-parent/jwicket-ui/jwicket-ui-effects/pom.xml
+++ b/jwicket-parent/jwicket-ui/jwicket-ui-effects/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-jwicket-ui</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jwicket-parent/jwicket-ui/jwicket-ui-resize/pom.xml
+++ b/jwicket-parent/jwicket-ui/jwicket-ui-resize/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-jwicket-ui</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jwicket-parent/jwicket-ui/jwicket-ui-sort/pom.xml
+++ b/jwicket-parent/jwicket-ui/jwicket-ui-sort/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-jwicket-ui</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/jwicket-parent/jwicket-ui/jwicket-ui-tooltip/pom.xml
+++ b/jwicket-parent/jwicket-ui/jwicket-ui-tooltip/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>wicketstuff-jwicket-ui</artifactId>
     <groupId>org.wicketstuff</groupId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>wicketstuff-jwicket-ui-tooltip</artifactId>

--- a/jwicket-parent/jwicket-ui/pom.xml
+++ b/jwicket-parent/jwicket-ui/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-jwicket-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 	
     <artifactId>wicketstuff-jwicket-ui</artifactId>

--- a/jwicket-parent/pom.xml
+++ b/jwicket-parent/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-jwicket-parent</artifactId>

--- a/lambda-parent/lambda-examples/pom.xml
+++ b/lambda-parent/lambda-examples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-lambda-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-lambda-examples</artifactId>

--- a/lambda-parent/lambda/pom.xml
+++ b/lambda-parent/lambda/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-lambda-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-lambda</artifactId>

--- a/lambda-parent/pom.xml
+++ b/lambda-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-lambda-parent</artifactId>

--- a/lightbox2-parent/lightbox2-examples/pom.xml
+++ b/lightbox2-parent/lightbox2-examples/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>lightbox2-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>lightbox2-examples</artifactId>

--- a/lightbox2-parent/lightbox2/pom.xml
+++ b/lightbox2-parent/lightbox2/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>lightbox2-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>lightbox2</artifactId>

--- a/lightbox2-parent/pom.xml
+++ b/lightbox2-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>lightbox2-parent</artifactId>

--- a/mbeanview-parent/mbeanview-examples/pom.xml
+++ b/mbeanview-parent/mbeanview-examples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>mbeanview-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>mbeanview-examples</artifactId>

--- a/mbeanview-parent/mbeanview/pom.xml
+++ b/mbeanview-parent/mbeanview/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>mbeanview-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-mbeanview</artifactId>

--- a/mbeanview-parent/pom.xml
+++ b/mbeanview-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>mbeanview-parent</artifactId>

--- a/minis-parent/minis-examples/pom.xml
+++ b/minis-parent/minis-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>minis-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-minis-examples</artifactId>

--- a/minis-parent/minis/pom.xml
+++ b/minis-parent/minis/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>minis-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-minis</artifactId>

--- a/minis-parent/pom.xml
+++ b/minis-parent/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>minis-parent</artifactId>

--- a/modalx-parent/modalx-examples/pom.xml
+++ b/modalx-parent/modalx-examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>modalx-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>modalx-examples</artifactId>

--- a/modalx-parent/modalx/pom.xml
+++ b/modalx-parent/modalx/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>modalx-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>modalx</artifactId>

--- a/modalx-parent/pom.xml
+++ b/modalx-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>modalx-parent</artifactId>
 	<name>ModalX Parent</name>

--- a/objectautocomplete-parent/objectautocomplete-examples/pom.xml
+++ b/objectautocomplete-parent/objectautocomplete-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
       <groupId>org.wicketstuff</groupId>
       <artifactId>wicketstuff-objectautocomplete-parent</artifactId>
-      <version>7.1.0-SNAPSHOT</version>
+      <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-objectautocomplete-examples</artifactId>

--- a/objectautocomplete-parent/objectautocomplete/pom.xml
+++ b/objectautocomplete-parent/objectautocomplete/pom.xml
@@ -5,7 +5,7 @@
     <parent>
       <groupId>org.wicketstuff</groupId>
       <artifactId>wicketstuff-objectautocomplete-parent</artifactId>
-      <version>7.1.0-SNAPSHOT</version>
+      <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-objectautocomplete</artifactId>

--- a/objectautocomplete-parent/pom.xml
+++ b/objectautocomplete-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-objectautocomplete-parent</artifactId>

--- a/openlayers-parent/openlayers-examples/pom.xml
+++ b/openlayers-parent/openlayers-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>openlayers-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>openlayers-examples</artifactId>

--- a/openlayers-parent/openlayers-proxy/pom.xml
+++ b/openlayers-parent/openlayers-proxy/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>openlayers-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-openlayers-proxy</artifactId>

--- a/openlayers-parent/openlayers/pom.xml
+++ b/openlayers-parent/openlayers/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>openlayers-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-openlayers</artifactId>

--- a/openlayers-parent/pom.xml
+++ b/openlayers-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>openlayers-parent</artifactId>

--- a/openlayers3-parent/openlayers3-bootstrap/pom.xml
+++ b/openlayers3-parent/openlayers3-bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>openlayers3-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-openlayers3-bootstrap</artifactId>

--- a/openlayers3-parent/openlayers3-examples/pom.xml
+++ b/openlayers3-parent/openlayers3-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>openlayers3-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>openlayers3-examples</artifactId>

--- a/openlayers3-parent/openlayers3/pom.xml
+++ b/openlayers3-parent/openlayers3/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>openlayers3-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
     <artifactId>wicketstuff-openlayers3</artifactId>

--- a/openlayers3-parent/pom.xml
+++ b/openlayers3-parent/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.wicketstuff</groupId>
     <artifactId>wicketstuff-core</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
   </parent>
 
   <artifactId>openlayers3-parent</artifactId>

--- a/phonebook/pom.xml
+++ b/phonebook/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-phonebook</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.wicketstuff</groupId>
 	<artifactId>wicketstuff-core</artifactId>
 	<packaging>pom</packaging>
-	<version>7.1.0-SNAPSHOT</version>
+	<version>7.1.0</version>
 	<name>WicketStuff Core Parent</name>
 	<description>
 		WicketStuff Core Parent is the parent project for all of the core WicketStuff projects.  It tries
@@ -237,7 +237,7 @@
 	</mailingLists>
 
 	<scm>
-		<url>https://github.com/wicketstuff/core</url>
+		<url>https://github.com/wicketstuff/core/tree/wicketstuff-core-7.1.0</url>
 		<connection>scm:git:ssh://git@github.com:wicketstuff/core.git</connection>
 	</scm>
 

--- a/portlet-parent/pom.xml
+++ b/portlet-parent/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-portlet-parent</artifactId>
 	<name>Portlet Parent</name>

--- a/portlet-parent/wicketstuff-portlet/pom.xml
+++ b/portlet-parent/wicketstuff-portlet/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-portlet-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-portlet</artifactId>

--- a/progressbar-parent/pom.xml
+++ b/progressbar-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>progressbar-parent</artifactId>

--- a/progressbar-parent/progressbar-example/pom.xml
+++ b/progressbar-parent/progressbar-example/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>progressbar-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>progressbar-example</artifactId>

--- a/progressbar-parent/progressbar-spring/pom.xml
+++ b/progressbar-parent/progressbar-spring/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>progressbar-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-progressbar-spring</artifactId>
 	<description>TaskService for use with user submitted background tasks and the progress bar. Could be used with Spring or any other application framework.</description>

--- a/progressbar-parent/progressbar/pom.xml
+++ b/progressbar-parent/progressbar/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>progressbar-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-progressbar</artifactId>

--- a/push-parent/pom.xml
+++ b/push-parent/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>push-parent</artifactId>

--- a/push-parent/push-cometd/pom.xml
+++ b/push-parent/push-cometd/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>push-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-push-cometd</artifactId>

--- a/push-parent/push-core/pom.xml
+++ b/push-parent/push-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>push-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-push-core</artifactId>

--- a/push-parent/push-examples/pom.xml
+++ b/push-parent/push-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>push-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-push-examples</artifactId>

--- a/push-parent/push-timer/pom.xml
+++ b/push-parent/push-timer/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>push-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-push-timer</artifactId>

--- a/scala-extensions-parent/pom.xml
+++ b/scala-extensions-parent/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	
 	<groupId>org.wicketstuff.scala</groupId>

--- a/scala-extensions-parent/wicket-scala-archetype/pom.xml
+++ b/scala-extensions-parent/wicket-scala-archetype/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff.scala</groupId>
 		<artifactId>scala-extensions-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<packaging>maven-archetype</packaging>	

--- a/scala-extensions-parent/wicket-scala-sample/pom.xml
+++ b/scala-extensions-parent/wicket-scala-sample/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff.scala</groupId>
 		<artifactId>scala-extensions-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-sample</artifactId>

--- a/scala-extensions-parent/wicket-scala/pom.xml
+++ b/scala-extensions-parent/wicket-scala/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff.scala</groupId>
 		<artifactId>scala-extensions-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-scala</artifactId>

--- a/select2-parent/pom.xml
+++ b/select2-parent/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-select2-parent</artifactId>
 	<packaging>pom</packaging>

--- a/select2-parent/select2-examples/pom.xml
+++ b/select2-parent/select2-examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>wicketstuff-select2-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-select2-examples</artifactId>
 	<packaging>war</packaging>

--- a/select2-parent/select2/pom.xml
+++ b/select2-parent/select2/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-select2-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>wicketstuff-select2</artifactId>

--- a/serializer-common/pom.xml
+++ b/serializer-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wicketstuff</groupId>
     <artifactId>wicketstuff-core</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
   </parent>
 
   <artifactId>wicketstuff-serializer-common</artifactId>

--- a/serializer-fast/pom.xml
+++ b/serializer-fast/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wicketstuff</groupId>
     <artifactId>wicketstuff-core</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
   </parent>
 
   <artifactId>wicketstuff-serializer-fast</artifactId>

--- a/serializer-fast2/pom.xml
+++ b/serializer-fast2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wicketstuff</groupId>
     <artifactId>wicketstuff-core</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
   </parent>
 
   <artifactId>wicketstuff-serializer-fast2</artifactId>

--- a/serializer-kryo/pom.xml
+++ b/serializer-kryo/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wicketstuff</groupId>
     <artifactId>wicketstuff-core</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
   </parent>
 
   <artifactId>wicketstuff-serializer-kryo</artifactId>

--- a/serializer-kryo2/pom.xml
+++ b/serializer-kryo2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wicketstuff</groupId>
     <artifactId>wicketstuff-core</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
   </parent>
 
   <artifactId>wicketstuff-serializer-kryo2</artifactId>

--- a/serializer-ui/pom.xml
+++ b/serializer-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.wicketstuff</groupId>
     <artifactId>wicketstuff-core</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
   </parent>
 
   <artifactId>wicketstuff-serializer-ui</artifactId>

--- a/shiro-security/pom.xml
+++ b/shiro-security/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicket-shiro-parent</artifactId>

--- a/shiro-security/wicket-shiro-examples/pom.xml
+++ b/shiro-security/wicket-shiro-examples/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-shiro-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicket-shiro-examples</artifactId>

--- a/shiro-security/wicket-shiro-examples/shiro-example-base/pom.xml
+++ b/shiro-security/wicket-shiro-examples/shiro-example-base/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-shiro-examples</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicket-shiro-example-base</artifactId>

--- a/shiro-security/wicket-shiro-examples/shiro-example-realm/pom.xml
+++ b/shiro-security/wicket-shiro-examples/shiro-example-realm/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-shiro-examples</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicket-shiro-example-realm</artifactId>

--- a/shiro-security/wicket-shiro-examples/shiro-example-spring-hibernate-native/pom.xml
+++ b/shiro-security/wicket-shiro-examples/shiro-example-spring-hibernate-native/pom.xml
@@ -23,7 +23,7 @@
     <parent>
       <groupId>org.wicketstuff</groupId>
       <artifactId>wicket-shiro-examples</artifactId>
-			<version>7.1.0-SNAPSHOT</version>
+			<version>7.1.0</version>
     </parent>
 
     <artifactId>wicket-shiro-example-spring-hibernate-native</artifactId>

--- a/shiro-security/wicket-shiro-examples/shiro-example-spring-hibernate/pom.xml
+++ b/shiro-security/wicket-shiro-examples/shiro-example-spring-hibernate/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-shiro-examples</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicket-shiro-example-spring-hibernate</artifactId>

--- a/shiro-security/wicket-shiro-examples/shiro-example-spring-jdbc/pom.xml
+++ b/shiro-security/wicket-shiro-examples/shiro-example-spring-jdbc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
       <groupId>org.wicketstuff</groupId>
       <artifactId>wicket-shiro-examples</artifactId>
-			<version>7.1.0-SNAPSHOT</version>
+			<version>7.1.0</version>
     </parent>
 
     <artifactId>wicket-shiro-example-spring-jdbc</artifactId>

--- a/shiro-security/wicket-shiro/pom.xml
+++ b/shiro-security/wicket-shiro/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-shiro-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-shiro</artifactId>

--- a/simile-timeline-parent/pom.xml
+++ b/simile-timeline-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>simile-timeline-parent</artifactId>

--- a/simile-timeline-parent/simile-timeline/pom.xml
+++ b/simile-timeline-parent/simile-timeline/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>simile-timeline-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-simile-timeline</artifactId>

--- a/sitemap-xml-parent/pom.xml
+++ b/sitemap-xml-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
     <name>sitemap-xml-parent</name>
     <developers>

--- a/sitemap-xml-parent/sitemap-xml-examples/pom.xml
+++ b/sitemap-xml-parent/sitemap-xml-examples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>sitemap-xml-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
     <name>sitemap-xml-examples</name>  
     <artifactId>wicketstuff-sitemap-xml-examples</artifactId>

--- a/sitemap-xml-parent/sitemap-xml/pom.xml
+++ b/sitemap-xml-parent/sitemap-xml/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>sitemap-xml-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
     <name>wicketstuff-sitemap-xml</name>
     <packaging>jar</packaging>

--- a/stateless-parent/pom.xml
+++ b/stateless-parent/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-stateless-parent</artifactId>

--- a/stateless-parent/stateless-examples/pom.xml
+++ b/stateless-parent/stateless-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-stateless-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-stateless-examples</artifactId>

--- a/stateless-parent/stateless/pom.xml
+++ b/stateless-parent/stateless/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-stateless-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-stateless</artifactId>

--- a/tinymce3-parent/pom.xml
+++ b/tinymce3-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>tinymce3-parent</artifactId>

--- a/tinymce3-parent/tinymce3-examples/pom.xml
+++ b/tinymce3-parent/tinymce3-examples/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>tinymce3-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>tinymce3-examples</artifactId>

--- a/tinymce3-parent/tinymce3/pom.xml
+++ b/tinymce3-parent/tinymce3/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>tinymce3-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-tinymce3</artifactId>

--- a/tinymce4-parent/pom.xml
+++ b/tinymce4-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>tinymce4-parent</artifactId>

--- a/tinymce4-parent/tinymce4-examples/pom.xml
+++ b/tinymce4-parent/tinymce4-examples/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>tinymce4-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>tinymce4-examples</artifactId>

--- a/tinymce4-parent/tinymce4/pom.xml
+++ b/tinymce4-parent/tinymce4/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>tinymce4-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-tinymce4</artifactId>

--- a/twitter-parent/pom.xml
+++ b/twitter-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>twitter-parent</artifactId>

--- a/twitter-parent/twitter-examples/pom.xml
+++ b/twitter-parent/twitter-examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>twitter-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-twitter-examples</artifactId>
 	<packaging>war</packaging>

--- a/twitter-parent/twitter/pom.xml
+++ b/twitter-parent/twitter/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>twitter-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-twitter</artifactId>

--- a/urlfragment-parent/pom.xml
+++ b/urlfragment-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
       <groupId>org.wicketstuff</groupId>
       <artifactId>wicketstuff-core</artifactId>
-      <version>7.1.0-SNAPSHOT</version>
+      <version>7.1.0</version>
   </parent>
     
   <artifactId>wicketstuff-urlfragment-parent</artifactId>

--- a/urlfragment-parent/urlfragment-example/pom.xml
+++ b/urlfragment-parent/urlfragment-example/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-urlfragment-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-urlfragment-examples</artifactId>

--- a/urlfragment-parent/urlfragment/pom.xml
+++ b/urlfragment-parent/urlfragment/pom.xml
@@ -21,7 +21,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-urlfragment-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>wicketstuff-urlfragment</artifactId>

--- a/whiteboard-parent/pom.xml
+++ b/whiteboard-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-whiteboard-parent</artifactId>

--- a/whiteboard-parent/whiteboard-examples/pom.xml
+++ b/whiteboard-parent/whiteboard-examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>wicketstuff-whiteboard-parent</artifactId>
         <groupId>org.wicketstuff</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-whiteboard-examples</artifactId>

--- a/whiteboard-parent/whiteboard/pom.xml
+++ b/whiteboard-parent/whiteboard/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<artifactId>wicketstuff-whiteboard-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-whiteboard</artifactId>

--- a/wicket-bundle-parent/pom.xml
+++ b/wicket-bundle-parent/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.wicketstuff</groupId>
     <artifactId>wicketstuff-core</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
   </parent>
 
   <artifactId>wicket-bundle-parent</artifactId>

--- a/wicket-bundle-parent/wicket-bundle/pom.xml
+++ b/wicket-bundle-parent/wicket-bundle/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.wicketstuff</groupId>
     <artifactId>wicket-bundle-parent</artifactId>
-    <version>7.1.0-SNAPSHOT</version>
+    <version>7.1.0</version>
   </parent>
 
   <artifactId>wicketstuff-bundle</artifactId>

--- a/wicket-bundle-parent/wicket-ioc-bundle/pom.xml
+++ b/wicket-bundle-parent/wicket-ioc-bundle/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>wicket-bundle-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-ioc-bundle</artifactId>
 	<packaging>bundle</packaging>

--- a/wicket-facebook-parent/pom.xml
+++ b/wicket-facebook-parent/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<name>Wicket Facebook :: Parent</name>

--- a/wicket-facebook-parent/wicket-facebook-examples/pom.xml
+++ b/wicket-facebook-parent/wicket-facebook-examples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>wicket-facebook-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicket-facebook-examples</artifactId>
 	<name>Wicket Facebook Examples</name>

--- a/wicket-facebook-parent/wicket-facebook/pom.xml
+++ b/wicket-facebook-parent/wicket-facebook/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>wicket-facebook-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicket-facebook</artifactId>
 	<name>Wicket Facebook</name>

--- a/wicket-foundation/pom.xml
+++ b/wicket-foundation/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
     <groupId>org.wicketstuff.foundation</groupId>

--- a/wicket-foundation/wicket-foundation-core/pom.xml
+++ b/wicket-foundation/wicket-foundation-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.wicketstuff.foundation</groupId>
         <artifactId>wicket-foundation-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
     
     <artifactId>wicket-foundation-core</artifactId>

--- a/wicket-foundation/wicket-foundation-samples/pom.xml
+++ b/wicket-foundation/wicket-foundation-samples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>wicket-foundation-parent</artifactId>
         <groupId>org.wicketstuff.foundation</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicket-foundation-samples</artifactId>

--- a/wicket-html5-parent/pom.xml
+++ b/wicket-html5-parent/pom.xml
@@ -7,7 +7,7 @@
     <parent>
     	<groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-html5-parent</artifactId>

--- a/wicket-html5-parent/wicket-html5-examples/pom.xml
+++ b/wicket-html5-parent/wicket-html5-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-html5-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-html5-examples</artifactId>

--- a/wicket-html5-parent/wicket-html5/pom.xml
+++ b/wicket-html5-parent/wicket-html5/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-html5-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-html5</artifactId>

--- a/wicket-mount-parent/pom.xml
+++ b/wicket-mount-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicket-mount-parent</artifactId>

--- a/wicket-mount-parent/wicket-mount-core/pom.xml
+++ b/wicket-mount-parent/wicket-mount-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicket-mount-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/wicket-mount-parent/wicket-mount-example/pom.xml
+++ b/wicket-mount-parent/wicket-mount-example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>wicket-mount-parent</artifactId>
         <groupId>org.wicketstuff</groupId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <groupId>org.wicketstuff</groupId>

--- a/wicket-mount-parent/wicket-mount/pom.xml
+++ b/wicket-mount-parent/wicket-mount/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicket-mount-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>wicket-mount</artifactId>

--- a/wicket-osgi-parent/pom.xml
+++ b/wicket-osgi-parent/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicket-osgi-parent</artifactId>
 	<name>Wicket OSGi Parent</name>

--- a/wicket-osgi-parent/wicket-osgi-test-service/pom.xml
+++ b/wicket-osgi-parent/wicket-osgi-test-service/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>wicket-osgi-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicket-osgi-test-service</artifactId>
 	<packaging>bundle</packaging>

--- a/wicket-osgi-parent/wicket-osgi-test-web/pom.xml
+++ b/wicket-osgi-parent/wicket-osgi-test-web/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>wicket-osgi-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicket-osgi-test-web</artifactId>
 	<packaging>bundle</packaging>

--- a/wicket-osgi-parent/wicket-osgi/pom.xml
+++ b/wicket-osgi-parent/wicket-osgi/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>wicket-osgi-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-osgi</artifactId>
 	<packaging>bundle</packaging>

--- a/wicket-poi-parent/pom.xml
+++ b/wicket-poi-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicket-poi-parent</artifactId>

--- a/wicket-poi-parent/wicket-poi-examples/pom.xml
+++ b/wicket-poi-parent/wicket-poi-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-poi-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicket-poi-examples</artifactId>

--- a/wicket-poi-parent/wicket-poi/pom.xml
+++ b/wicket-poi-parent/wicket-poi/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-poi-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-poi</artifactId>

--- a/wicket-security-parent/pom.xml
+++ b/wicket-security-parent/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>wicket-security-parent</artifactId>

--- a/wicket-security-parent/swarm-parent/hive/pom.xml
+++ b/wicket-security-parent/swarm-parent/hive/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-security-swarm-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-security-hive</artifactId>
 	<packaging>jar</packaging>

--- a/wicket-security-parent/swarm-parent/pom.xml
+++ b/wicket-security-parent/swarm-parent/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-security-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicket-security-swarm-parent</artifactId>
 	<packaging>pom</packaging>

--- a/wicket-security-parent/swarm-parent/swarm/pom.xml
+++ b/wicket-security-parent/swarm-parent/swarm/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-security-swarm-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-security-swarm</artifactId>
 	<packaging>jar</packaging>

--- a/wicket-security-parent/wasp-parent/pom.xml
+++ b/wicket-security-parent/wasp-parent/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-security-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicket-security-wasp-parent</artifactId>
 	<packaging>pom</packaging>

--- a/wicket-security-parent/wasp-parent/wasp/pom.xml
+++ b/wicket-security-parent/wasp-parent/wasp/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-security-wasp-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-security-wasp</artifactId>
 	<packaging>jar</packaging>

--- a/wicket-security-parent/wasp-parent/wicomsec/pom.xml
+++ b/wicket-security-parent/wasp-parent/wicomsec/pom.xml
@@ -20,7 +20,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicket-security-wasp-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 	<artifactId>wicketstuff-security-wicomsec</artifactId>
 	<packaging>jar</packaging>

--- a/wicket-servlet3-parent/pom.xml
+++ b/wicket-servlet3-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-servlet3-parent</artifactId>

--- a/wicket-servlet3-parent/wicket-servlet3-auth/pom.xml
+++ b/wicket-servlet3-parent/wicket-servlet3-auth/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-servlet3-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-servlet3-auth</artifactId>

--- a/wicket-servlet3-parent/wicket-servlet3-examples/pom.xml
+++ b/wicket-servlet3-parent/wicket-servlet3-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-servlet3-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-servlet3-examples</artifactId>

--- a/wicketstuff-glassfish4-integration/pom.xml
+++ b/wicketstuff-glassfish4-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>    
     <artifactId>wicketstuff-glassfish4-integration</artifactId>
     <packaging>jar</packaging>

--- a/wicketstuff-lazymodel/pom.xml
+++ b/wicketstuff-lazymodel/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-lazymodel</artifactId>

--- a/wicketstuff-logback-parent/pom.xml
+++ b/wicketstuff-logback-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-logback-parent</artifactId>

--- a/wicketstuff-logback-parent/wicketstuff-logback-examples/pom.xml
+++ b/wicketstuff-logback-parent/wicketstuff-logback-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-logback-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-logback-examples</artifactId>

--- a/wicketstuff-logback-parent/wicketstuff-logback/pom.xml
+++ b/wicketstuff-logback-parent/wicketstuff-logback/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-logback-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-logback</artifactId>

--- a/wicketstuff-restannotations-parent/pom.xml
+++ b/wicketstuff-restannotations-parent/pom.xml
@@ -16,7 +16,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-restannotations-parent</artifactId>

--- a/wicketstuff-restannotations-parent/restannotations-examples/pom.xml
+++ b/wicketstuff-restannotations-parent/restannotations-examples/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<artifactId>wicketstuff-restannotations-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<groupId>org.wicketstuff</groupId>

--- a/wicketstuff-restannotations-parent/restannotations-json/pom.xml
+++ b/wicketstuff-restannotations-parent/restannotations-json/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<artifactId>wicketstuff-restannotations-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-restannotations-json</artifactId>

--- a/wicketstuff-restannotations-parent/restannotations/pom.xml
+++ b/wicketstuff-restannotations-parent/restannotations/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<artifactId>wicketstuff-restannotations-parent</artifactId>
 		<groupId>org.wicketstuff</groupId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-restannotations</artifactId>

--- a/wicketstuff-selectize-parent/pom.xml
+++ b/wicketstuff-selectize-parent/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-selectize-parent</artifactId>

--- a/wicketstuff-springreference-parent/pom.xml
+++ b/wicketstuff-springreference-parent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-core</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-springreference-parent</artifactId>

--- a/wicketstuff-springreference-parent/wicketstuff-springreference-examples/pom.xml
+++ b/wicketstuff-springreference-parent/wicketstuff-springreference-examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-springreference-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-springreference-examples</artifactId>

--- a/wicketstuff-springreference-parent/wicketstuff-springreference/pom.xml
+++ b/wicketstuff-springreference-parent/wicketstuff-springreference/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.wicketstuff</groupId>
 		<artifactId>wicketstuff-springreference-parent</artifactId>
-		<version>7.1.0-SNAPSHOT</version>
+		<version>7.1.0</version>
 	</parent>
 
 	<artifactId>wicketstuff-springreference</artifactId>

--- a/yui-parent/pom.xml
+++ b/yui-parent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-core</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <artifactId>wicketstuff-yui-parent</artifactId>

--- a/yui-parent/yui-calendar/pom.xml
+++ b/yui-parent/yui-calendar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-yui-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/yui-parent/yui-common/pom.xml
+++ b/yui-parent/yui-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wicketstuff</groupId>
         <artifactId>wicketstuff-yui-parent</artifactId>
-        <version>7.1.0-SNAPSHOT</version>
+        <version>7.1.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Remove references to the Wicket.Browser.isIELessThan7 function in script-jq.js as this has been removed from wicket core 7.1.

This causes UncaughtTypeErrors in javascript when referencing Inmethod.XTableManager functions.