### PR TITLE
log4j dependency as test, replace commons-logging with jcl-over-slf4j

### DIFF
--- a/gmap3-parent/gmap3/pom.xml
+++ b/gmap3-parent/gmap3/pom.xml
@@ -32,8 +32,8 @@ limitations under the License.
     
     <dependencies>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -42,10 +42,12 @@ limitations under the License.
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
* log4j is only used for test
* since we use SLF4J, replace commons-logging with jcl-over-slf4j