### PR TITLE
since we use SLF4J, replace commons-logging and log4j are only used for test

### DIFF
--- a/gmap3-parent/gmap3/pom.xml
+++ b/gmap3-parent/gmap3/pom.xml
@@ -34,6 +34,7 @@ limitations under the License.
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -42,10 +43,12 @@ limitations under the License.
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
since we use SLF4J, replace commons-logging and log4j are only used for test