### PR TITLE
[offline-mode] Minor improvements

### DIFF
--- a/offline-mode-parent/offline-mode-examples/src/main/java/org/wicketstuff/offline/mode/OfflineModeHomePage.java
+++ b/offline-mode-parent/offline-mode-examples/src/main/java/org/wicketstuff/offline/mode/OfflineModeHomePage.java
@@ -24,7 +24,7 @@ public class OfflineModeHomePage extends WebPage
 		super.renderHead(response);
 		response.render(JavaScriptHeaderItem.forReference(OfflineModeScript.getInstance()));
 
-		// load the offline mode scripts on page request
-		OfflineCache.load(response);
+		// contribute the offline mode scripts on page request
+		OfflineCache.renderHead(response);
 	}
 }

--- a/offline-mode-parent/offline-mode-examples/src/main/java/org/wicketstuff/offline/mode/OfflineModeScript.java
+++ b/offline-mode-parent/offline-mode-examples/src/main/java/org/wicketstuff/offline/mode/OfflineModeScript.java
@@ -9,7 +9,7 @@ public class OfflineModeScript extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = 1L;
 
-	private static OfflineModeScript self;
+	private static final OfflineModeScript self = new OfflineModeScript();
 
 	private static String id = UUID.randomUUID().toString();
 
@@ -18,12 +18,8 @@ public class OfflineModeScript extends JavaScriptResourceReference
 		super(OfflineModeScript.class, OfflineModeScript.class.getSimpleName() + ".js");
 	}
 
-	public static synchronized OfflineModeScript getInstance()
+	public static OfflineModeScript getInstance()
 	{
-		if (self == null)
-		{
-			self = new OfflineModeScript();
-		}
 		return self;
 	}
 
@@ -41,7 +37,7 @@ public class OfflineModeScript extends JavaScriptResourceReference
 				String response = new String(processResponse);
 				response = response.replace("$(scriptId)", "\"" + id + "\"");
 				return response.getBytes();
-			};
+			}
 		};
 		removeCompressFlagIfUnnecessary(resource);
 		return resource;

--- a/offline-mode-parent/offline-mode-examples/src/main/resources/org/wicketstuff/offline/mode/OfflineModeHomePage.html
+++ b/offline-mode-parent/offline-mode-examples/src/main/resources/org/wicketstuff/offline/mode/OfflineModeHomePage.html
@@ -1,4 +1,4 @@
-<html>
+<html xmlns:wicket="http://wicket.apache.org">
 	<head>
 		<title>OfflineModePage</title>
 	</head>

--- a/offline-mode-parent/offline-mode/src/main/java/org/wicketstuff/offline/mode/OfflineCacheEntry.java
+++ b/offline-mode-parent/offline-mode/src/main/java/org/wicketstuff/offline/mode/OfflineCacheEntry.java
@@ -63,7 +63,7 @@ public class OfflineCacheEntry
 
 		private String realName;
 
-		private Cors(String realName)
+		Cors(String realName)
 		{
 			this.realName = realName;
 		}

--- a/offline-mode-parent/offline-mode/src/main/java/org/wicketstuff/offline/mode/ServiceWorker.java
+++ b/offline-mode-parent/offline-mode/src/main/java/org/wicketstuff/offline/mode/ServiceWorker.java
@@ -23,6 +23,8 @@ import org.apache.wicket.Page;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.ajax.json.JSONArray;
 import org.apache.wicket.ajax.json.JSONObject;
+import org.apache.wicket.markup.head.HeaderItem;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.request.IRequestHandler;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.http.WebResponse;
@@ -45,9 +47,9 @@ public class ServiceWorker extends JavaScriptResourceReference
 
 	private static ServiceWorker self;
 
-	private String cacheName;
+	private final String cacheName;
 
-	private List<OfflineCacheEntry> offlineCacheEntries;
+	private final List<OfflineCacheEntry> offlineCacheEntries;
 
 	/**
 	 * Creates the service worker
@@ -70,7 +72,7 @@ public class ServiceWorker extends JavaScriptResourceReference
 	 * 
 	 * @return the service worker instance
 	 */
-	public synchronized static ServiceWorker getInstance()
+	public static ServiceWorker getInstance()
 	{
 		return self;
 	}
@@ -122,7 +124,7 @@ public class ServiceWorker extends JavaScriptResourceReference
 								"Please provide a cache object to each OfflineCacheEntry.");
 						}
 
-						CharSequence urlFor = null;
+						CharSequence urlFor;
 						if (cacheObject instanceof ResourceReference)
 						{
 							urlFor = requestCycle.urlFor((ResourceReference)cacheObject,
@@ -148,7 +150,7 @@ public class ServiceWorker extends JavaScriptResourceReference
 						}
 						else if (urlFor.toString().startsWith("."))
 						{
-							urlFor = urlFor.toString().substring(0 + 1);
+							urlFor = urlFor.toString().substring(1);
 						}
 
 						String url = urlFor.toString() + (suffix != null ? suffix : "");
@@ -175,4 +177,10 @@ public class ServiceWorker extends JavaScriptResourceReference
 		return resource;
 	}
 
+	@Override
+	public List<HeaderItem> getDependencies() {
+		List<HeaderItem> dependencies = super.getDependencies();
+		dependencies.add(JavaScriptHeaderItem.forReference(ServiceWorkerRegistration.getInstance()));
+		return dependencies;
+	}
 }

--- a/offline-mode-parent/offline-mode/src/main/java/org/wicketstuff/offline/mode/ServiceWorkerRegistration.java
+++ b/offline-mode-parent/offline-mode/src/main/java/org/wicketstuff/offline/mode/ServiceWorkerRegistration.java
@@ -30,7 +30,7 @@ public class ServiceWorkerRegistration extends JavaScriptResourceReference
 {
 	private static final long serialVersionUID = -1356650275121621624L;
 
-	private static ServiceWorkerRegistration self;
+	private static final ServiceWorkerRegistration self = new ServiceWorkerRegistration();
 
 	/**
 	 * Creates a new service worker registration
@@ -46,12 +46,8 @@ public class ServiceWorkerRegistration extends JavaScriptResourceReference
 	 * 
 	 * @return the current service worker registration instance
 	 */
-	public synchronized static ServiceWorkerRegistration getInstance()
+	public static ServiceWorkerRegistration getInstance()
 	{
-		if (self == null)
-		{
-			self = new ServiceWorkerRegistration();
-		}
 		return self;
 	}
 

--- a/offline-mode-parent/offline-mode/src/main/resources/org/wicketstuff/offline/mode/ServiceWorker.js
+++ b/offline-mode-parent/offline-mode/src/main/resources/org/wicketstuff/offline/mode/ServiceWorker.js
@@ -19,10 +19,10 @@ var wicketCacheName = '$(cacheName)';
 // register cache
 self.addEventListener('install', function(event) {
 	var offlineCacheEntries = $(offlineCacheEntries);
-	console.log("Received the following settings to be cached: "+JSON.stringify(offlineCacheEntries)+", entries with cors are going to be translated to a Request object");
+	console.info("Received the following settings to be cached: "+JSON.stringify(offlineCacheEntries)+", entries with CORS are going to be translated to a Request object");
 	
-	// Handle cors settings
-	for(i = 0; i < offlineCacheEntries.length; i++) {
+	// Handle CORS settings
+	for(var i = 0; i < offlineCacheEntries.length; i++) {
 		if(offlineCacheEntries[i].cors) {
 			offlineCacheEntries[i] = new Request(offlineCacheEntries[i].url, { mode : offlineCacheEntries[i].cors } );
 		}else{
@@ -42,7 +42,7 @@ self.addEventListener('fetch', function(event) {
 			return cache.match(event.request).then(function(response) {
 				// Handles requests
 				var responseValue = response || fetch(event.request);
-				console.log('Found response in cache:', responseValue);
+				console.info('Found response in cache:', responseValue);
 				return responseValue;
 			}).catch(function(error) {
 				// Handles exceptions that arise from match() or fetch().

--- a/offline-mode-parent/offline-mode/src/main/resources/org/wicketstuff/offline/mode/ServiceWorkerRegistration.js
+++ b/offline-mode-parent/offline-mode/src/main/resources/org/wicketstuff/offline/mode/ServiceWorkerRegistration.js
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 if ('serviceWorker' in navigator) {
-	navigator.serviceWorker.register('wicketserviceworker' /*, {scope: './'}*/).then(function(registration) {
-		console.log('wicketserviceworker has been initialized');
+	navigator.serviceWorker.register('wicket-offlinecache-serviceworker' /*, {scope: './'}*/).then(function(registration) {
+		console.info('Wicket Service Worker has been initialized');
 	}).catch(function(error) {
-		console.log('Error while initializing the wicketserviceworker: '+error);
-		throw 'Error while initializing the wicketserviceworker: '+error;
+		console.error('Error while initializing the Wicket Service Worker: '+error);
+		throw 'Error while initializing the Wicket Offline Cache Service Worker: '+error;
 	});
 } else {
-	console.log('wicketserviceworker is not supported within the current browser');
+	console.warn('Service Worker is not supported within the current browser');
 }


### PR DESCRIPTION
Store the cacheable entries in the application metadata.
Use eager singletons instead of synchronizing (on the class!) for each #getInstance() call.
Add namespace to the mount paths. Used '-' instead of '/' because otherwise the url resolving breaks.
Use ResourceReference#getDependencies() to make sure that ServiceWorker is always used with ServiceWorkerRegistration.
Rename OfflineCache#load() to #renderHead() to be in sync with all other similar methods.