### PR TITLE
Fix similar mapped path (very similar problem of #462)

### DIFF
--- a/wicketstuff-restannotations-parent/restannotations/src/main/java/org/wicketstuff/rest/resource/AbstractRestResource.java
+++ b/wicketstuff-restannotations-parent/restannotations/src/main/java/org/wicketstuff/rest/resource/AbstractRestResource.java
@@ -433,6 +433,7 @@ public abstract class AbstractRestResource<T extends IWebSerialDeserial> impleme
 		 * score method calculateScore is executed for every segment.
 		 */
 		int highestScore = 0;
+		int highestCount = 0;
 
 		for (MethodMappingInfo mappedMethod : mappedMethodsCandidates)
 		{
@@ -448,19 +449,24 @@ public abstract class AbstractRestResource<T extends IWebSerialDeserial> impleme
 					break;
 				}
 			}
-			
-			if(highestScore > 0 && scoredMethod.getScore() == highestScore)
-			{
-				// if we have more than one method with the highest score, throw
-				// ambiguous exception.
-				throwAmbiguousMethodsException(scoredMethod, highiestScoredMethod);
-			}
 
 			if (scoredMethod.getScore() >= highestScore)
 			{
+				if(scoredMethod.getScore() == highestScore) {
+					highestCount++;
+				} else {
+					highestCount = 1;
+				}
 				highestScore = scoredMethod.getScore();
 				highiestScoredMethod = scoredMethod;
-			} 
+			}
+		}
+
+		// if we have more than one method with the highest score, throw
+		// ambiguous exception.
+		if(highestCount > 1)
+		{
+			throwAmbiguousMethodsException(highiestScoredMethod);
 		}
 				
 		return highiestScoredMethod;

--- a/wicketstuff-restannotations-parent/restannotations/src/test/java/org/wicketstuff/rest/resource/RestResourceFullAnnotated.java
+++ b/wicketstuff-restannotations-parent/restannotations/src/test/java/org/wicketstuff/rest/resource/RestResourceFullAnnotated.java
@@ -226,6 +226,11 @@ public class RestResourceFullAnnotated extends AbstractRestResource<TextualWebSe
 	public String getFromAnotherPath(@RequestParam("term") String term) {
 	    return "getFromAnotherPath";
 	}
+	
+	@MethodMapping(value = "/path/get_from_another_path2", produces = RestMimeTypes.TEXT_PLAIN)
+	public String getFromAnotherPath2(@RequestParam("term") String term) {
+	    return "getFromPath2";
+	}
 }
 
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
I have the following **three** methods mapped:

```java
	@MethodMapping(value = "/user/auth/", httpMethod = HttpMethod.POST)
	public Object AuthUserByEmail(@RequestBody User user) {
		return "hoge";
	}
	
	@MethodMapping(value = "/user/login/", httpMethod = HttpMethod.POST)
	public Object login(@RequestBody User user) {
		return "hoge";
	}
	
	@MethodMapping(value = "/user/logout/", httpMethod = HttpMethod.POST)
	public Object logout(@RequestBody User user) {
		return "hoge";
	}
```

When I visit this url localhost:8080/mountpoint/path/user/auth, I get the following error:
```java
WARN  - RequestCycleExtra          - ********************************
WARN  - RequestCycleExtra          - Handling the following exception
org.apache.wicket.WicketRuntimeException: Ambiguous methods mapped for the current request: URL 'api/v1/user/auth', HTTP method POST. Mapped methods: logout, login
	at org.wicketstuff.rest.resource.AbstractRestResource.throwAmbiguousMethodsException(AbstractRestResource.java:494)
	at org.wicketstuff.rest.resource.AbstractRestResource.selectMostSuitedMethod(AbstractRestResource.java:460)
	at org.wicketstuff.rest.resource.AbstractRestResource.respond(AbstractRestResource.java:180)
	at org.apache.wicket.request.handler.resource.ResourceRequestHandler.respond(ResourceRequestHandler.java:105)
	at org.apache.wicket.request.handler.resource.ResourceReferenceRequestHandler.respond(ResourceReferenceRequestHandler.java:108)
	at org.apache.wicket.request.cycle.RequestCycle$HandlerExecutor.respond(RequestCycle.java:895)
	at org.apache.wicket.request.RequestHandlerStack.execute(RequestHandlerStack.java:64)
	at org.apache.wicket.request.cycle.RequestCycle.execute(RequestCycle.java:265)
	at org.apache.wicket.request.cycle.RequestCycle.processRequest(RequestCycle.java:222)
	at org.apache.wicket.request.cycle.RequestCycle.processRequestAndDetach(RequestCycle.java:293)
	at org.apache.wicket.protocol.http.WicketFilter.processRequestCycle(WicketFilter.java:261)
	at org.apache.wicket.protocol.http.WicketFilter.processRequest(WicketFilter.java:203)
	at org.apache.wicket.protocol.http.WicketFilter.doFilter(WicketFilter.java:284)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:585)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:577)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:223)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:215)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:110)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.Server.handle(Server.java:499)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:310)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
WARN  - RequestCycleExtra          - ********************************
ERROR - DefaultExceptionMapper     - Unexpected error occurred
org.apache.wicket.WicketRuntimeException: Ambiguous methods mapped for the current request: URL 'api/v1/user/auth', HTTP method POST. Mapped methods: logout, login
	at org.wicketstuff.rest.resource.AbstractRestResource.throwAmbiguousMethodsException(AbstractRestResource.java:494)
	at org.wicketstuff.rest.resource.AbstractRestResource.selectMostSuitedMethod(AbstractRestResource.java:460)
	at org.wicketstuff.rest.resource.AbstractRestResource.respond(AbstractRestResource.java:180)
	at org.apache.wicket.request.handler.resource.ResourceRequestHandler.respond(ResourceRequestHandler.java:105)
	at org.apache.wicket.request.handler.resource.ResourceReferenceRequestHandler.respond(ResourceReferenceRequestHandler.java:108)
	at org.apache.wicket.request.cycle.RequestCycle$HandlerExecutor.respond(RequestCycle.java:895)
	at org.apache.wicket.request.RequestHandlerStack.execute(RequestHandlerStack.java:64)
	at org.apache.wicket.request.cycle.RequestCycle.execute(RequestCycle.java:265)
	at org.apache.wicket.request.cycle.RequestCycle.processRequest(RequestCycle.java:222)
	at org.apache.wicket.request.cycle.RequestCycle.processRequestAndDetach(RequestCycle.java:293)
	at org.apache.wicket.protocol.http.WicketFilter.processRequestCycle(WicketFilter.java:261)
	at org.apache.wicket.protocol.http.WicketFilter.processRequest(WicketFilter.java:203)
	at org.apache.wicket.protocol.http.WicketFilter.doFilter(WicketFilter.java:284)
	at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1652)
	at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:585)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:143)
	at org.eclipse.jetty.security.SecurityHandler.handle(SecurityHandler.java:577)
	at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:223)
	at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1127)
	at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:515)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:185)
	at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1061)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.ContextHandlerCollection.handle(ContextHandlerCollection.java:215)
	at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:110)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:97)
	at org.eclipse.jetty.server.Server.handle(Server.java:499)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:310)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:257)
	at org.eclipse.jetty.io.AbstractConnection$2.run(AbstractConnection.java:540)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:635)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:555)
	at java.lang.Thread.run(Thread.java:745)
```

I fixed the problem. 
You can run the test by running testSimilarMountedPath() which is already exists in RestResourcesTest.java

Please check my PR and give me feedback.