### PR TITLE
wicketstuff-portlet: fixies of #482 and #502

### DIFF
--- a/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/PortletUrlRenderer.java
+++ b/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/PortletUrlRenderer.java
@@ -1,33 +1,57 @@
 package org.apache.wicket.portlet;
 
+import javax.portlet.PortletRequest;
+
 import org.apache.wicket.request.Request;
 import org.apache.wicket.request.UrlRenderer;
 import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.string.PrependingStringBuffer;
 
 /**
- * {@link UrlRenderer} for Portlet Applications.
+ * <h1>{@link UrlRenderer} for Portlet Applications.</h1>
+ * <p>
+ * It corrects the base Url. All the generated URLs will be relative to this Url.
+ * </p>
+ * <p>
+ * The base Url depends on the lifecycle phase of the current portlet request.
+ * </p>
+ * <ul>
+ * <li>During the RENDER or the ACTION phase the base url must be set with the request url which is
+ * relative to the wicket filter path {@link Request#getUrl()}.  
+ * </li>
+ * <li>During the RESOURCE phase the base url must be set with the client url
+ * {@link Request#getClientUrl()}. Every Ajax request to the portal is a RESOURCE request and the
+ * comments of the {@link Request#getClientUrl()} method full explain the reasons that this url must
+ * be the base url during this phase.</li> </u>
  * 
+ * <p>
  * It overrides the {@link #renderContextRelativeUrl(String)} method in order to give the capability
  * to wicket portlets to serve static and context-relative resources.
+ * </p>
  * 
  * @author Konstantinos Karavitis
  * 
  */
 public class PortletUrlRenderer extends UrlRenderer
 {
-
 	/**
 	 * @param request
+	 * 
+	 * 
+	 * 
 	 */
 	public PortletUrlRenderer(Request request)
 	{
 		super(request);
+		
+		PortletRequest portletRequest = ThreadPortletContext.getPortletRequest();
+		String lifecyclePhase = (String) portletRequest.getAttribute(PortletRequest.LIFECYCLE_PHASE);
+		if (!PortletRequest.RESOURCE_PHASE.equals(lifecyclePhase)) {
+			//request is not an ajax request, so put as base url the relative to Wicket filter path url.
+			setBaseUrl(request.getUrl());
+		}
 	}
-
-	/**
-	 * @see {@link UrlRenderer#renderContextRelativeUrl(String)}
-	 **/
+	
 	@Override
 	public String renderContextRelativeUrl(String url)
 	{
@@ -43,5 +67,4 @@ public class PortletUrlRenderer extends UrlRenderer
 
 		return buffer.toString();
 	}
-
 }

--- a/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/WicketPortlet.java
+++ b/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/WicketPortlet.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -653,24 +652,10 @@ public class WicketPortlet extends GenericPortlet {
 		if ((url != null) && (requestUrl != null) && (!ABSOLUTE_URI_PATTERN.matcher(url).matches())) {
 			try {
 				if (!requestUrl.startsWith("http")) {
-					URL fixedUrl = new URL("http:" + url);
-					String query = fixedUrl.getQuery();
-					if (query != null) {
-						String wuViewParam = "_wuview=";
-						for (String queryParamValuePair : query.split("&")) {
-							if (queryParamValuePair.startsWith(wuViewParam)) {
-								return URLDecoder.decode(queryParamValuePair
-										.replace(wuViewParam, ""), "UTF-8")
-										+ "?" + query;
-							}
-						}
-					}
-
-					return new URL(new URL("http:" + wicketFilterPath), url)
-							.toString().substring(5);
+					return new URL(new URL("http:" + requestUrl), url).toString().substring(5);
 				}
 				else {
-					return new URL(new URL(wicketFilterPath), url).getPath();
+					return new URL(new URL(requestUrl), url).getPath();
 				}
 			}
 			catch (Exception e) {


### PR DESCRIPTION
This pull request solves a major problem in apache wicket portlet bridge which I describe in the following lines.

When the RequestCycle creates a UrlRenderer instance it sets as base url the client url of the current processing org.apache.wicket.request.Request instance.

```
public UrlRenderer(final Request request)
{
       this.request = request;
       baseUrl = request.getClientUrl();
}
```
In a web application the above approach is correct as it is explained in the comments of the method
org.apache.wicket.request.Request#getClientUrl() which I repeat here.

```
/**
	 * Returns the url against which the client, usually the browser, will resolve relative urls in
	 * the rendered markup. If the client is a browser this is the url in the browser's address bar.
	 * 
	 * <p>
	 * Under normal circumstances the client and request ({@link #getUrl()}) urls are the same.
	 * Handling an Ajax request, however, is a good example of when they may be different.
	 * Technologies such as XHR are free to request whatever url they wish <strong>without
	 * modifying</strong> the client url; however, any produced urls will be evaluated by the client
	 * against the client url - not against the request url.
	 * </p>
	 * <p>
	 * Lets take a simple example: <br>
	 * 
	 * Suppose we are on a client detail page. This page contains an Ajax link which opens a list of
	 * client's orders. Each order has a link that goes to the order detail page.
	 * 
	 * The client detail page is located at
	 * 
	 * <pre>
	 * /detail/customer/15
	 * </pre>
	 * 
	 * and the order detail page is located at
	 * 
	 * <pre>
	 * /order/22
	 * </pre>
	 * 
	 * The Ajax link which renders the detail section is located at
	 * 
	 * <pre>
	 *  /detail/wicket?page 3
	 * </pre>
	 * 
	 * Lets run through the execution and see what happens when the XHR request is processed:
	 * 
	 * <pre>
	 * request 1: /details/customer/15
	 * client url: details/customer/15 (the url in the browser's address bar)
	 * request url: details/customer/15
	 * Wicket renders relative Ajax details anchor as ../../wicket/page?3  
	 * 
	 * ../../wicket/page?3 resolved against current client url details/customer/15 yields:
	 * request 2: /wicket/page?3
	 * client url: customer/15 (unchanged since XHRs requests dont change it)
	 * request url: wicket/ajax/page?3
	 * 
	 * now Wicket has to render a relative url to /details/order/22. If Wicket renders 
	 * it against the request url it will be: ../order/22, and later evaluated on the
	 * client will result in /customer/order/22 which is incorrect.
	 * </pre>
	 * 
	 * This is why implementations of {@link Request} must track the client url, so that relative
	 * urls can be rendered against the same url they will be evaluated against on the client -
	 * which is not always the same as the request url. For example, Wicket's Ajax implementation
	 * always sends the current client url in a header along with the XHR request so that Wicket can
	 * correctly render relative urls against it.
	 * </p>
	 * 
	 * @return client url
	 */
	public abstract Url getClientUrl();
```
But in portlets world the base url of the UrlRenderer must depent on the portlet lifecycle phase.

 On the RENDER phase the base url must be the request url which is relative to the wicket filter path 
and the WebPageRenderer will render correctly the page that this url instructs.
 On the ACTION phase the base url must be the request url which is relative to the wicket filter path 
and if so then the redirect url will be "portletified" correctly. 
 Finally during every ajax request which is a RESOURCE request  the base url must be the client url, the xhr url as the above comments explains. 