### PR TITLE
Fix the delete action when there are two editable grids on one page.

### DIFF
--- a/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/column/EditableGridActionsPanel.java
+++ b/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/column/EditableGridActionsPanel.java
@@ -100,9 +100,10 @@ public abstract class EditableGridActionsPanel<T> extends Panel
 			@Override
 			public void onClick(AjaxRequestTarget target)
 			{
+				EditableDataTable eventTarget = rowItem.findParent(EditableDataTable.class);
 				send(getPage(), Broadcast.BREADTH, new GridOperationData<T>(OperationType.DELETE,
-					(T)rowItem.getDefaultModelObject()));
-				target.add(rowItem.findParent(EditableDataTable.class));
+					(T)rowItem.getDefaultModelObject(), eventTarget));
+				target.add(eventTarget);
 				onDelete(target);
 			}
 

--- a/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/component/EditableDataTable.java
+++ b/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/component/EditableDataTable.java
@@ -525,7 +525,8 @@ public class EditableDataTable<T, S> extends Panel implements IPageableItems, IC
 			@SuppressWarnings("unchecked")
 			GridOperationData<T> gridOperationData = (GridOperationData<T>)event.getPayload();
 			if (null != gridOperationData &&
-				OperationType.DELETE.equals(gridOperationData.getOperationType()))
+				OperationType.DELETE.equals(gridOperationData.getOperationType()) &&
+						  this.equals(gridOperationData.getTarget()))
 			{
 				getDataProvider().remove(gridOperationData.getData());
 				event.stop();

--- a/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/model/GridOperationData.java
+++ b/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/model/GridOperationData.java
@@ -1,5 +1,7 @@
 package org.wicketstuff.egrid.model;
 
+import org.wicketstuff.egrid.component.EditableDataTable;
+
 import java.io.Serializable;
 /**
  * 
@@ -12,11 +14,13 @@ public class GridOperationData<D> implements Serializable
 	private static final long serialVersionUID = 1L;
 	private OperationType operationType;
 	private D data;
+	private EditableDataTable target;
 
-	public GridOperationData(final OperationType newOperationType, final D newData)
+	public GridOperationData(final OperationType newOperationType, final D newData, EditableDataTable target)
 	{
 		this.operationType = newOperationType;
-		this.data			=  newData;
+		this.data			 = newData;
+		this.target        = target;
 	}
 	
 	public OperationType getOperationType()
@@ -34,5 +38,9 @@ public class GridOperationData<D> implements Serializable
 	public void setData(D data)
 	{
 		this.data = data;
+	}
+	public EditableDataTable getTarget()
+	{
+		return target;
 	}
 }


### PR DESCRIPTION
When a page holds two editable grids, a delete event on the second grid will be performed by the first grid. First and second positions are in the order in which they were added to the page. This happens because the delete action is propagated as a message, but this message does not hold the object that receives the event. Thus the first EditableDataTable that receives the message will process it. I have added the receiving EditableDataTable objevt into the message payload and added a check for it  in the event processing.

Changes:

- GridOperationData.java: Added a field to the GridOperationData payload to hold the EditableDataTable that receives the onClick event
- EditableDataTable.java: Added a check in the onEvent method in EditableDataTable so that each object will only process its own events.
- EditableGridActionsPanel: Added the receiving datatable object to the payload in EditableGridActionsPanel