### PR TITLE
Google Charts: Text and Value marker support

### DIFF
--- a/jdk-1.5-parent/googlecharts-parent/googlecharts-examples/src/main/java/org/wicketstuff/googlecharts/examples/Home.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts-examples/src/main/java/org/wicketstuff/googlecharts/examples/Home.java
@@ -19,6 +19,8 @@ import org.wicketstuff.googlecharts.LinearGradientFill;
 import org.wicketstuff.googlecharts.MarkerType;
 import org.wicketstuff.googlecharts.ShapeMarker;
 import org.wicketstuff.googlecharts.SolidFill;
+import org.wicketstuff.googlecharts.TextValueMarker;
+import org.wicketstuff.googlecharts.TextValueMarkerType;
 
 /**
  * @author Daniel Spiewak
@@ -78,6 +80,7 @@ public class Home extends WebPage {
         provider.addShapeMarker(new ShapeMarker(MarkerType.SQUARE, Color.RED, 0, -1, 5));
         provider.addShapeMarker(new ShapeMarker(MarkerType.SQUARE, Color.BLUE, 1, -1, 5));
         provider.addShapeMarker(new ShapeMarker(MarkerType.SQUARE, Color.decode("#00aa00"), 2, -1, 5));
+        provider.addTextValueMarker(new TextValueMarker(TextValueMarkerType.FORMATTING_STRING, "*f0*", 0, Color.GREEN, -1, 11));
 
         add(new Chart("lineChart", provider));
 

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/Chart.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/Chart.java
@@ -90,6 +90,7 @@ public class Chart extends WebComponent implements Serializable {
             addParameter(url, "chm", render(provider.getRangeMarkers()));
             addParameter(url, "chls", render(provider.getLineStyles()));
             addParameter(url, "chm", render(provider.getFillAreas()));
+            addParameter(url, "chm", render(provider.getTextValueMarkers()));
             addParameter(url, "chl", render(provider.getPieLabels()));
 
             return url;
@@ -524,6 +525,29 @@ public class Chart extends WebComponent implements Serializable {
             back.append(0).append(',');
             back.append(marker.getStart()).append(',');
             back.append(marker.getEnd()).append('|');
+        }
+
+        if (back.length() > 0) {
+            back.setLength(back.length() - 1);
+        }
+
+        return back;
+    }
+
+    private CharSequence render(ITextValueMarker[] markers) {
+        if (markers == null) {
+            return null;
+        }
+
+        StringBuilder back = new StringBuilder();
+
+        for (ITextValueMarker marker : markers) {
+            back.append(render(marker.getType()));
+            back.append(render(marker.getText())).append(',');
+            back.append(render(marker.getColor())).append(',');
+            back.append(marker.getIndex()).append(',');
+            back.append(marker.getPoint()).append(',');
+            back.append(marker.getSize()).append('|');
         }
 
         if (back.length() > 0) {

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/ChartProvider.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/ChartProvider.java
@@ -27,6 +27,7 @@ public class ChartProvider implements IChartProvider {
     private String[] pieLabels;
     private List<IRangeMarker> rangeMarkers = new ArrayList<IRangeMarker>();
     private List<IShapeMarker> shapeMarkers = new ArrayList<IShapeMarker>();
+    private List<ITextValueMarker> textValueMarkers = new ArrayList<ITextValueMarker>();
     private Dimension size;
     private String title;
     private ChartType type;
@@ -88,6 +89,10 @@ public class ChartProvider implements IChartProvider {
 
     public IShapeMarker[] getShapeMarkers() {
         return shapeMarkers.toArray(new IShapeMarker[shapeMarkers.size()]);
+    }
+
+    public ITextValueMarker[] getTextValueMarkers() {
+        return textValueMarkers.toArray(new ITextValueMarker[textValueMarkers.size()]);
     }
 
     public Dimension getSize() {
@@ -152,6 +157,10 @@ public class ChartProvider implements IChartProvider {
 
     public void addShapeMarker(IShapeMarker shapeMarker) {
         shapeMarkers.add(shapeMarker);
+    }
+
+    public void addTextValueMarker(ITextValueMarker textValueMarker) {
+        textValueMarkers.add(textValueMarker);
     }
 
     public void setSize(Dimension size) {

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/IChartProvider.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/IChartProvider.java
@@ -45,4 +45,6 @@ public interface IChartProvider extends Serializable {
     public IRangeMarker[] getRangeMarkers();
 
     public IFillArea[] getFillAreas();
+
+    public ITextValueMarker[] getTextValueMarkers();
 }

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/ITextValueMarker.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/ITextValueMarker.java
@@ -1,0 +1,19 @@
+package org.wicketstuff.googlecharts;
+
+import java.awt.*;
+import java.io.Serializable;
+
+public interface ITextValueMarker extends Serializable {
+
+    public TextValueMarkerType getType();
+
+    public Color getColor();
+
+    public int getIndex();
+
+    public double getPoint();
+
+    public int getSize();
+
+    public String getText();
+}

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/TextValueMarker.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/TextValueMarker.java
@@ -1,0 +1,70 @@
+package org.wicketstuff.googlecharts;
+
+import java.awt.*;
+
+public class TextValueMarker implements ITextValueMarker {
+    private static final long serialVersionUID = -7521556909378737717L;
+    private TextValueMarkerType type;
+    private String text;
+    private int index = -1;
+    private Color color;
+    private double point = -1;
+    private int size = -1;
+
+    public TextValueMarker(TextValueMarkerType type, String text, int index, Color color, double point, int size) {
+        this.type = type;
+        this.text = text;
+        this.index = index;
+        this.color = color;
+        this.point = point;
+        this.size = size;
+    }
+
+    public TextValueMarkerType getType() {
+        return type;
+    }
+
+    public void setType(TextValueMarkerType type) {
+        this.type = type;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public Color getColor() {
+        return color;
+    }
+
+    public void setColor(Color color) {
+        this.color = color;
+    }
+
+    public double getPoint() {
+        return point;
+    }
+
+    public void setPoint(double point) {
+        this.point = point;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+}

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/TextValueMarkerType.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/TextValueMarkerType.java
@@ -1,0 +1,20 @@
+package org.wicketstuff.googlecharts;
+
+public enum TextValueMarkerType {
+
+    FLAG("f"),
+    SIMPLE_TEXT("t"),
+    ANNOTATION("A"),
+    FORMATTING_STRING("N"),
+    ;
+
+    private final String rendering;
+
+    private TextValueMarkerType(String rendering) {
+        this.rendering = rendering;
+    }
+
+    public String getRendering() {
+        return rendering;
+    }
+}


### PR DESCRIPTION
Add support for Google Charts Text and Value markers as an additional
marker type.

For reference see
<https://developers.google.com/chart/image/docs/gallery/line_charts#text-and--data-value-markers-chm-bar-line------radar-scatter>