### PR TITLE
Google Charts: Add data scaling parameter support

### DIFF
--- a/jdk-1.5-parent/googlecharts-parent/googlecharts-examples/src/main/java/org/wicketstuff/googlecharts/examples/Home.html
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts-examples/src/main/java/org/wicketstuff/googlecharts/examples/Home.html
@@ -32,5 +32,10 @@
         <div style="z-index:1;position:absolute;right:40px;top:0">
             <img src="http://www.bandlem.com/Alex/AlexHeadshotRight.png"/>
         </div>
+
+        <h2>Data scaling</h2>
+
+        <img wicket:id="dataScaling"/>
+
     </body>
 </html>

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts-examples/src/main/java/org/wicketstuff/googlecharts/examples/Home.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts-examples/src/main/java/org/wicketstuff/googlecharts/examples/Home.java
@@ -13,6 +13,7 @@ import org.wicketstuff.googlecharts.ChartAxisType;
 import org.wicketstuff.googlecharts.ChartDataEncoding;
 import org.wicketstuff.googlecharts.ChartProvider;
 import org.wicketstuff.googlecharts.ChartType;
+import org.wicketstuff.googlecharts.DataScaling;
 import org.wicketstuff.googlecharts.IChartData;
 import org.wicketstuff.googlecharts.LineStyle;
 import org.wicketstuff.googlecharts.LinearGradientFill;
@@ -179,5 +180,34 @@ public class Home extends WebPage {
         provider.addAxis(axis);
 
         add(new Chart("alex", provider));
+
+        // Data scaling example
+        data = new AbstractChartData(ChartDataEncoding.TEXT, 1.0d) {
+
+            public double[][] getData() {
+                return new double[][]{
+                        {0.114, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                        {0.0, 0.275, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                        {0.0, 0.0, 0.024, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                        {0.0, 0.0, 0.0, 0.024, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                        {0.0, 0.0, 0.0, 0.0, 0.054000000000000006, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                        {0.0, 0.0, 0.0, 0.0, 0.0, 0.102, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
+                        {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.078, 0.0, 0.0, 0.0, 0.0, 0.0},
+                        {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.054000000000000006, 0.0, 0.0, 0.0, 0.0},
+                        {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.084, 0.0, 0.0, 0.0},
+                        {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.066, 0.0, 0.0},
+                        {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.084, 0.0},
+                        {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.042}
+                };
+            }
+        };
+
+        provider = new ChartProvider(new Dimension(600, 250), ChartType.BAR_VERTICAL_SET, data);
+        provider.addDataScaling(new DataScaling(0.0f, 1.0f));
+        provider.setColors(new Color[]{Color.GREEN, Color.BLUE, Color.RED});
+        provider.setLegend(new String[]{"2005", "2006", "2007"});
+        provider.setBackgroundFill(new SolidFill(new Color(0, 0, 0, 0)));
+
+        add(new Chart("dataScaling", provider));
     }
 }

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/Chart.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/Chart.java
@@ -49,6 +49,7 @@ public class Chart extends WebComponent implements Serializable {
 
             addParameter(url, "chs", render(provider.getSize()));
             addParameter(url, "chd", render(provider.getData()));
+            addParameter(url, "chds", render(provider.getDataScaling()));
             addParameter(url, "cht", render(provider.getType()));
             addParameter(url, "chbh", render(provider.getBarWidth(), provider.getBarGroupSpacing()));
             addParameter(url, "chtt", render(provider.getTitle()));
@@ -602,6 +603,34 @@ public class Chart extends WebComponent implements Serializable {
         }
 
         return back;
+    }
+
+    private CharSequence render(IDataScaling[] dataScaling) {
+        if (dataScaling == null) {
+            return null;
+        }
+
+        StringBuilder param = new StringBuilder();
+
+        for (IDataScaling scaling : dataScaling) {
+            if (scaling == null) {
+                param.append('|');
+                continue;
+            }
+
+            if (scaling.isAutoScale()) {
+                param.append('a').append('|');
+            } else {
+                param.append(scaling.getMinimum()).append(',');
+                param.append(scaling.getMaximum()).append('|');
+            }
+        }
+
+        if (param.length() > 0) {
+            param.setLength(param.length() - 1);
+        }
+
+        return param;
     }
 
     @Override

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/ChartProvider.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/ChartProvider.java
@@ -32,6 +32,7 @@ public class ChartProvider implements IChartProvider {
     private String title;
     private ChartType type;
     private IChartData data;
+    private List<IDataScaling> dataScalingList = new ArrayList<IDataScaling>();
 
     public ChartProvider(Dimension size, ChartType type, IChartData data) {
         this.size = size;
@@ -93,6 +94,14 @@ public class ChartProvider implements IChartProvider {
 
     public ITextValueMarker[] getTextValueMarkers() {
         return textValueMarkers.toArray(new ITextValueMarker[textValueMarkers.size()]);
+    }
+
+    public void addDataScaling(IDataScaling dataScaling) {
+        dataScalingList.add(dataScaling);
+    }
+
+    public IDataScaling[] getDataScaling() {
+        return dataScalingList.toArray(new IDataScaling[dataScalingList.size()]);
     }
 
     public Dimension getSize() {

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/DataScaling.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/DataScaling.java
@@ -1,0 +1,34 @@
+package org.wicketstuff.googlecharts;
+
+public class DataScaling implements IDataScaling {
+
+    private final Float min;
+    private final Float max;
+    private final boolean autoScale;
+
+    public DataScaling(boolean autoScale) {
+        this(autoScale, null, null);
+    }
+
+    public DataScaling(Float min, Float max) {
+        this(false, min, max);
+    }
+
+    private DataScaling(boolean autoScale, Float min, Float max) {
+        this.autoScale = autoScale;
+        this.min = !autoScale ? min : null;
+        this.max = !autoScale ? max : null;
+    }
+
+    public boolean isAutoScale() {
+        return autoScale;
+    }
+
+    public Float getMinimum() {
+        return min;
+    }
+
+    public Float getMaximum() {
+        return max;
+    }
+}

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/IChartProvider.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/IChartProvider.java
@@ -47,4 +47,6 @@ public interface IChartProvider extends Serializable {
     public IFillArea[] getFillAreas();
 
     public ITextValueMarker[] getTextValueMarkers();
+
+    public IDataScaling[] getDataScaling();
 }

--- a/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/IDataScaling.java
+++ b/jdk-1.5-parent/googlecharts-parent/googlecharts/src/main/java/org/wicketstuff/googlecharts/IDataScaling.java
@@ -1,0 +1,10 @@
+package org.wicketstuff.googlecharts;
+
+public interface IDataScaling {
+
+    boolean isAutoScale();
+
+    Float getMinimum();
+
+    Float getMaximum();
+}


### PR DESCRIPTION
Adds support for specifying data scaling.

Reference: https://developers.google.com/chart/image/docs/data_formats

Signed-off-by: Andreas Häber <andreas.haber@intele.com>