### PR TITLE
ofchart wicket 6 fix

### DIFF
--- a/dashboard-parent/dashboard-examples/src/main/java/org/wicketstuff/dashboard/examples/ofchart/DemoChartDataFactory.java
+++ b/dashboard-parent/dashboard-examples/src/main/java/org/wicketstuff/dashboard/examples/ofchart/DemoChartDataFactory.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import org.wicketstuff.dashboard.widgets.ofchart.ChartDataFactory;
 import org.wicketstuff.dashboard.widgets.ofchart.ChartWidget;
 
-import jofc2.model.Chart;
+import ro.nextreports.jofc2.model.Chart;
 
 /**
  * @author Decebal Suiu

--- a/dashboard-parent/dashboard-examples/src/main/java/org/wicketstuff/dashboard/examples/ofchart/DemoChartFactory.java
+++ b/dashboard-parent/dashboard-examples/src/main/java/org/wicketstuff/dashboard/examples/ofchart/DemoChartFactory.java
@@ -17,13 +17,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.Random;
 
-import jofc2.model.Chart;
-import jofc2.model.axis.XAxis;
-import jofc2.model.axis.YAxis;
-import jofc2.model.elements.BarChart;
-import jofc2.model.elements.LineChart;
-import jofc2.model.elements.PieChart;
-import jofc2.model.elements.ScatterChart;
+import ro.nextreports.jofc2.model.Chart;
+import ro.nextreports.jofc2.model.axis.XAxis;
+import ro.nextreports.jofc2.model.axis.YAxis;
+import ro.nextreports.jofc2.model.elements.BarChart;
+import ro.nextreports.jofc2.model.elements.LineChart;
+import ro.nextreports.jofc2.model.elements.PieChart;
+import ro.nextreports.jofc2.model.elements.ScatterChart;
 
 /**
  * @author Decebal Suiu

--- a/dashboard-parent/dashboard-widgets/dashboard-widgets-ofchart/pom.xml
+++ b/dashboard-parent/dashboard-widgets/dashboard-widgets-ofchart/pom.xml
@@ -17,17 +17,9 @@
 	<dependencies>
 		<!-- JOFC2 (open flash chart for java) -->
 		<dependency>
-			<groupId>jofc2</groupId>
+			<groupId>ro.nextreports</groupId>
 			<artifactId>jofc2</artifactId>
 			<version>${jofc2.version}</version>
 		</dependency>
 	</dependencies>
-
-	<repositories>
-		<repository>
-			<id>jofc2.maven.repo</id>
-			<name>JOFC2 GoogleCode.com Snapshot Repository</name>
-			<url>http://jofc2.googlecode.com/svn/repository/snapshots/</url>
-		</repository>
-	</repositories>
 </project>

--- a/dashboard-parent/dashboard-widgets/pom.xml
+++ b/dashboard-parent/dashboard-widgets/pom.xml
@@ -15,7 +15,7 @@
 	<name>Wicketstuff Dashboard Widgets</name>
 
 	<properties>
-		<jofc2.version>1.0.1-SNAPSHOT</jofc2.version>
+		<jofc2.version>1.0.1</jofc2.version>
 		<jqPlot.version>${project.version}</jqPlot.version>
 		<loremipsum.version>1.0</loremipsum.version>
 		<justGage.version>1.0.1</justGage.version>


### PR DESCRIPTION
replace ofchart dependency because old dependency's repository http://jofc2.googlecode.com/svn/repository/snapshots/ is not available anymore