### PR TITLE
prevent default action when clicking sort header

### DIFF
--- a/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/common/SortableHeaderLinkPanel.java
+++ b/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/common/SortableHeaderLinkPanel.java
@@ -2,6 +2,7 @@ package com.inmethod.grid.common;
 
 import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.html.panel.Panel;
 
@@ -57,6 +58,13 @@ public abstract class SortableHeaderLinkPanel<S> extends Panel
 				}
 
 				sortStateChanged(target);
+			}
+
+			@Override
+			protected void updateAjaxAttributes(AjaxRequestAttributes attributes)
+			{
+				super.updateAjaxAttributes(attributes);
+				attributes.setPreventDefault(true);
 			}
 		});
 	}


### PR DESCRIPTION
In Wicket 6.x, "allowDefault" defaulted to false. In Wicket 7, "preventDefault"
is false, inverting this behavior. Since the page should not scroll when
clicking on a sort header, we need to update the AjaxAttributes here to prevent
the default.

See also WICKET-5197 for the change in Wicket itself that causes this.