### PR TITLE
Fix the save action in an EditableGrid when there are more than 1 editable grids on the page

### DIFF
--- a/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/component/EditableDataTable.java
+++ b/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/component/EditableDataTable.java
@@ -517,8 +517,10 @@ public class EditableDataTable<T, S> extends Panel implements IPageableItems, IC
 		{
 			@SuppressWarnings("unchecked")
 			Item<T> rowItem = ((Item<T>)event.getPayload());
-			this.datagrid.refreash(rowItem);
-			event.stop();
+			if (rowItem.findParent(EditableDataTable.class).equals(this)) {
+				this.datagrid.refreash(rowItem);
+				event.stop();
+			}
 		}
 		else if (event.getPayload() instanceof GridOperationData)
 		{

--- a/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/component/EditableDataTable.java
+++ b/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/component/EditableDataTable.java
@@ -32,6 +32,7 @@ import org.wicketstuff.egrid.model.GridOperationData;
 import org.wicketstuff.egrid.model.OperationType;
 import org.wicketstuff.egrid.provider.IEditableDataProvider;
 import org.wicketstuff.egrid.toolbar.AbstractEditableGridToolbar;
+import org.wicketstuff.egrid.component.EditableDataTable;
 
 /**
  * 
@@ -517,11 +518,7 @@ public class EditableDataTable<T, S> extends Panel implements IPageableItems, IC
 		{
 			@SuppressWarnings("unchecked")
 			Item<T> rowItem = ((Item<T>)event.getPayload());
-<<<<<<< HEAD
 			if (rowItem.findParent(EditableDataTable.class).equals(this)) {
-=======
-			if (rowItem.findParent(org.wicketstuff.egrid.component.EditableDataTable.class).equals(this)) {
->>>>>>> 9534ea7... Fix save action when there is more than one grid in the same page
 				this.datagrid.refreash(rowItem);
 				event.stop();
 			}

--- a/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/component/EditableDataTable.java
+++ b/editable-grid-parent/editable-grid/src/main/java/org/wicketstuff/egrid/component/EditableDataTable.java
@@ -517,7 +517,11 @@ public class EditableDataTable<T, S> extends Panel implements IPageableItems, IC
 		{
 			@SuppressWarnings("unchecked")
 			Item<T> rowItem = ((Item<T>)event.getPayload());
+<<<<<<< HEAD
 			if (rowItem.findParent(EditableDataTable.class).equals(this)) {
+=======
+			if (rowItem.findParent(org.wicketstuff.egrid.component.EditableDataTable.class).equals(this)) {
+>>>>>>> 9534ea7... Fix save action when there is more than one grid in the same page
 				this.datagrid.refreash(rowItem);
 				event.stop();
 			}


### PR DESCRIPTION
Added a check in EditableDataTable.java to make sure the parent table of the affected grid row is the one that processes the message.

When a page holds two editable grids, the save event on a row on the second grid will be performed by the first grid. First and second positions are in the order in which they were added to the page. This happens because the save event is processed by the first EditableDataTable object that receives the message. 
