### PR TITLE
wicketstuff-portlet: fix for issue #559

### DIFF
--- a/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/PortletRequestMapper.java
+++ b/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/PortletRequestMapper.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import javax.portlet.MimeResponse;
+import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 import javax.portlet.PortletURL;
 import javax.portlet.ResourceURL;
@@ -84,7 +85,7 @@ public class PortletRequestMapper extends AbstractComponentMapper {
 		}
 
 		if (requestHandler instanceof RenderPageRequestHandler) {
-			if (ThreadPortletContext.isAjax()) {
+			if (PortletRequest.RESOURCE_PHASE.equals(ThreadPortletContext.getPortletRequest().getAttribute(PortletRequest.LIFECYCLE_PHASE))) {
 				url = encodeRenderUrl(url, true);
 			}
 		}

--- a/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/WicketPortlet.java
+++ b/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/WicketPortlet.java
@@ -431,15 +431,13 @@ public class WicketPortlet extends GenericPortlet {
 				else if (redirectLocation != null) {
 					// TODO: check if its redirect to wicket page (find _wu or
 					// _wuPortletMode or resourceId parameter)
-
-					redirectLocation = fixWicketUrl(wicketURL, redirectLocation, request.getScheme());
-
+					
 					final boolean validWicketUrl = redirectLocation.startsWith(wicketFilterPath);
 					if (validWicketUrl) {
 						if (previousURL == null || previousURL != redirectLocation) {
 							previousURL = wicketURL;
 							wicketURL = redirectLocation;
-							((RenderResponse) response).reset();
+							response.reset();
 							responseState.clear();
 							continue;
 						}


### PR DESCRIPTION
When a redirection to other wicket page occurs during a resource request, e.g a redirection to the InternalErrorPage because of an Exception during a download request, the redirect url is not a valid render url and the portal cannot redirect to the other wicket page.
This pull request is a fix for the above problem.