### PR TITLE
synchronize wicket-6.x branch with the latest fixes on wicket-7.x branch

### DIFF
--- a/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/PortletRequestMapper.java
+++ b/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/PortletRequestMapper.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import javax.portlet.MimeResponse;
+import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 import javax.portlet.PortletURL;
 import javax.portlet.ResourceURL;
@@ -56,6 +57,9 @@ import org.apache.wicket.util.crypt.Base64;
  * @author Konstantinos Karavitis
  */
 public class PortletRequestMapper extends AbstractComponentMapper {
+	
+	public static String PORTLET_URL = "portlet-url";
+	
 	private SystemMapper systemMapper;
 
 	public PortletRequestMapper(final Application application) {
@@ -80,7 +84,7 @@ public class PortletRequestMapper extends AbstractComponentMapper {
 		}
 
 		if (requestHandler instanceof RenderPageRequestHandler) {
-			if (ThreadPortletContext.isAjax()) {
+			if (PortletRequest.RESOURCE_PHASE.equals(ThreadPortletContext.getPortletRequest().getAttribute(PortletRequest.LIFECYCLE_PHASE))) {
 				url = encodeRenderUrl(url, true);
 			}
 		}
@@ -182,7 +186,7 @@ public class PortletRequestMapper extends AbstractComponentMapper {
 			url = parseUrl(qualifiedPath);
 		}
 
-		return url;
+		return markAsPortletUrl(url);
 	}
 
 	private Url encodeSharedResourceUrl(Url url) {
@@ -226,7 +230,7 @@ public class PortletRequestMapper extends AbstractComponentMapper {
 			url = parseUrl(qualifiedPath);
 		}
 
-		return url;
+		return markAsPortletUrl(url);
 	}
 
 	private Url encodeRenderUrl(Url url, boolean forceRenderUrl) {
@@ -252,6 +256,11 @@ public class PortletRequestMapper extends AbstractComponentMapper {
 			url = parseUrl(qualifiedPath);
 		}
 
+		return markAsPortletUrl(url);
+	}
+	
+	private Url markAsPortletUrl(Url url) {
+		url.setQueryParameter(PORTLET_URL, PORTLET_URL);
 		return url;
 	}
 }

--- a/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/PortletUrlRenderer.java
+++ b/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/PortletUrlRenderer.java
@@ -3,9 +3,11 @@ package org.apache.wicket.portlet;
 import javax.portlet.PortletRequest;
 
 import org.apache.wicket.request.Request;
+import org.apache.wicket.request.Url;
 import org.apache.wicket.request.UrlRenderer;
 import org.apache.wicket.util.lang.Args;
 import org.apache.wicket.util.string.PrependingStringBuffer;
+import org.apache.wicket.util.string.Strings;
 
 /**
  * <h1>{@link UrlRenderer} for Portlet Applications.</h1>
@@ -34,13 +36,17 @@ import org.apache.wicket.util.string.PrependingStringBuffer;
  */
 public class PortletUrlRenderer extends UrlRenderer
 {
-
+	
+	
+	private Request request;
+	
 	/**
 	 * @param request
 	 */
 	public PortletUrlRenderer(Request request)
 	{
 		super(request);
+		this.request = request;
 		
 		PortletRequest portletRequest = ThreadPortletContext.getPortletRequest();
 		String lifecyclePhase = (String) portletRequest.getAttribute(PortletRequest.LIFECYCLE_PHASE);
@@ -69,4 +75,57 @@ public class PortletUrlRenderer extends UrlRenderer
 		return buffer.toString();
 	}
 
+	
+	/**
+	 * Renders the Url
+	 * 
+	 * @param url
+	 * @return Url rendered as string
+	 */
+	public String renderUrl(final Url url)
+	{
+		
+		if (url.getQueryParameter(PortletRequestMapper.PORTLET_URL) != null) {
+			url.removeQueryParameters(PortletRequestMapper.PORTLET_URL);
+			return url.toString();
+		}
+		
+		CharSequence renderedUrl = super.renderUrl(url);
+		
+		Url absoluteUrl = Url.parse(renderedUrl);
+		Url clientUrl = request.getClientUrl();
+		if (!shouldRedirectToExternalUrl(absoluteUrl, clientUrl)) {
+			if (absoluteUrl.getProtocol() != null) {
+				renderedUrl = Strings.replaceAll(renderedUrl, absoluteUrl.getProtocol() + "://", "/");
+			}
+			if (absoluteUrl.getHost() != null) {
+				renderedUrl = Strings.replaceAll(renderedUrl, "/" + absoluteUrl.getHost(), "/");
+			}
+			if (absoluteUrl.getPort() != null) {
+				renderedUrl = Strings.replaceAll(renderedUrl, "/:" + absoluteUrl.getPort(), "/");
+
+			}
+			renderedUrl = Strings.replaceAll(renderedUrl, "//", "/");
+		}
+		
+		return renderedUrl.toString();
+	}
+	
+	private boolean shouldRedirectToExternalUrl(Url url, Url clientUrl) 
+	{
+		if (!Strings.isEmpty(url.getProtocol()) && !url.getProtocol().equals(clientUrl.getProtocol())) 
+		{
+			return true;
+		}
+		if (!Strings.isEmpty(url.getHost()) && !url.getHost().equals(clientUrl.getHost())) 
+		{
+			return true;
+		}
+		if ((url.getPort() != null) && !url.getPort().equals(clientUrl.getPort())) 
+		{
+			return true;
+		}
+		
+		return false;
+	}
 }

--- a/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/WicketPortlet.java
+++ b/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/WicketPortlet.java
@@ -293,10 +293,7 @@ public class WicketPortlet extends GenericPortlet {
 			// try to lookup the passed in wicket url parameter, suffixed with
 			// the portlet mode
 			String redirectUrlKey = WICKET_URL_PORTLET_PARAMETER + request.getPortletMode().toString();
-			String redirectUrl = request.getParameter(redirectUrlKey);
-			// if the wicket url is not in request parameters try to lookup into the action scoped
-			// attributes.
-			wicketURL = redirectUrl == null ? (String)request.getAttribute(redirectUrlKey) : redirectUrl;
+			wicketURL = request.getParameter(redirectUrlKey);
 		}
 
 		// if the wicketURL could not be retrieved, return the url for the
@@ -311,9 +308,6 @@ public class WicketPortlet extends GenericPortlet {
 	 */
 	@Override
 	public void init(final PortletConfig config) throws PortletException {
-		// enable action-scoped request attributes support (see JSR286 specification PLT.10.4.4)
-		config.getContainerRuntimeOptions().put("javax.portlet.actionScopedRequestAttributes",
-			new String[] { "true", "numberOfCachedScopes", "10" });
 		super.init(config);
 
 		wicketFilterPath = buildWicketFilterPath(config.getInitParameter(WICKET_FILTER_PATH_PARAM));
@@ -370,12 +364,12 @@ public class WicketPortlet extends GenericPortlet {
 		if (LOG.isDebugEnabled())
 			LOG.debug("redirectURL after include:" + redirectLocationUrl);
 		if (redirectLocationUrl != null && !redirectLocationUrl.isEmpty()) {
-			redirectLocationUrl = fixWicketUrl(wicketURL, redirectLocationUrl);
+			redirectLocationUrl = fixWicketUrl(wicketURL, redirectLocationUrl, request.getScheme());
 			if (redirectLocationUrl.startsWith(wicketFilterPath)) {
 				final String portletMode = request.getPortletMode().toString();
 				final String redirectUrlKey = WICKET_URL_PORTLET_PARAMETER + portletMode;
-				// put the redirect location into the "_wuview" action scoped request attribute
-				request.setAttribute(redirectUrlKey, redirectLocationUrl);
+				// put the redirect location into the "_wuview" render parameter
+				response.setRenderParameter(redirectUrlKey, redirectLocationUrl);
 			}
 			else
 				response.sendRedirect(redirectLocationUrl);
@@ -421,7 +415,6 @@ public class WicketPortlet extends GenericPortlet {
 				String ajaxRedirectLocation = responseState.getAjaxRedirectLocation();
 				if (ajaxRedirectLocation != null) {
 					// Ajax redirect
-					ajaxRedirectLocation = fixWicketUrl(wicketURL, ajaxRedirectLocation);
 					responseState.clear();
 					responseState.setDateHeader("Date", System.currentTimeMillis());
 					responseState.setDateHeader("Expires", 0);
@@ -439,14 +432,12 @@ public class WicketPortlet extends GenericPortlet {
 					// TODO: check if its redirect to wicket page (find _wu or
 					// _wuPortletMode or resourceId parameter)
 
-					redirectLocation = fixWicketUrl(wicketURL, redirectLocation);
-
 					final boolean validWicketUrl = redirectLocation.startsWith(wicketFilterPath);
 					if (validWicketUrl) {
 						if (previousURL == null || previousURL != redirectLocation) {
 							previousURL = wicketURL;
 							wicketURL = redirectLocation;
-							((RenderResponse) response).reset();
+							response.reset();
 							responseState.clear();
 							continue;
 						}
@@ -647,11 +638,11 @@ public class WicketPortlet extends GenericPortlet {
 	 *            the URL to fix
 	 * @return the corrected URL
 	 */
-	protected String fixWicketUrl(final String requestUrl, final String url) {
+	protected String fixWicketUrl(final String requestUrl, final String url, final String scheme) {
 		if ((url != null) && (requestUrl != null) && (!ABSOLUTE_URI_PATTERN.matcher(url).matches())) {
 			try {
 				if (!requestUrl.startsWith("http")) {
-					return new URL(new URL("http:" + requestUrl), url).toString().substring(5);
+					return new URL(new URL(scheme + ":" + requestUrl), url).toString().substring(scheme.length() + 1);
 				}
 				else {
 					return new URL(new URL(requestUrl), url).getPath();


### PR DESCRIPTION
- fix for issue #522: When the _wuview parameter is a non existed wicket
path then the liferay portal throws a StackOverFlowException error.
- fix for issue #531: Wicket portlet does not work at all when it is
into a served over SSL (HTTPS) portal page
- fix for issue #546: Absolute rendered urls cause problems when a
reverse proxy server serves requests on behalf of the portal server 
- Remove the action-scoped request attributes support usage and use
render parameters for transferring the wicket redirect url from action
phase to render phase. 
- fix for issue #555: Action, resource and render urls are not rendered
right in some cases on websphere portal.
- fix for issue #559: When an exception occurs during a resource request
(not ajax), the portlet does not redirect to its InternalErrorPage page.