### PR TITLE
Fix stop behavior

### DIFF
--- a/async-tasks-parent/async-tasks-impl/src/main/java/org/wicketstuff/async/components/ProgressButton.java
+++ b/async-tasks-parent/async-tasks-impl/src/main/java/org/wicketstuff/async/components/ProgressButton.java
@@ -1,5 +1,6 @@
 package org.wicketstuff.async.components;
 
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -174,9 +175,7 @@ public class ProgressButton extends AjaxFallbackButton {
     private void concludeIfApplicable(Optional<AjaxRequestTarget> targetOptional) {
         if (!getTaskContainer().isRunning()) {
         	targetOptional.ifPresent(target -> {
-                if(refreshBehavior.isBinded()) {
-                	refreshBehavior.stop(target);
-                }
+                refreshBehavior.stop(target);
             });
             if (getTaskContainer().isFailed()) {
                 onTaskError(targetOptional);
@@ -201,9 +200,7 @@ public class ProgressButton extends AjaxFallbackButton {
     }
 
     private class RefreshBehavior extends AbstractAjaxTimerBehavior {
-        private boolean binded = false;
-
-		public RefreshBehavior(Duration updateInterval) {
+        public RefreshBehavior(Duration updateInterval) {
             super(updateInterval);
         }
 
@@ -223,21 +220,6 @@ public class ProgressButton extends AjaxFallbackButton {
             // Again, skip the check for the component being enabled
             return !isStopped() && getComponent().findParent(Page.class) != null;
         }
-        @Override
-        protected void onBind() {
-        	super.onBind();
-        	binded   = true;
-        }
-        
-        @Override
-        protected void onUnbind() {
-        	super.onUnbind();
-        	binded = false;
-        }
-        
-        public boolean isBinded() {
-			return binded;
-		}
     }
 
     /**

--- a/async-tasks-parent/async-tasks-impl/src/main/java/org/wicketstuff/async/components/ProgressButton.java
+++ b/async-tasks-parent/async-tasks-impl/src/main/java/org/wicketstuff/async/components/ProgressButton.java
@@ -1,12 +1,5 @@
 package org.wicketstuff.async.components;
 
-import java.lang.reflect.Method;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-
 import org.apache.wicket.Component;
 import org.apache.wicket.Page;
 import org.apache.wicket.ajax.AbstractAjaxTimerBehavior;
@@ -19,6 +12,12 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.util.time.Duration;
 import org.wicketstuff.async.task.AbstractTaskContainer;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * A progress button which allows to control a {@link Runnable}. Each such button will refresh itself as given by
@@ -151,11 +150,7 @@ public class ProgressButton extends AjaxFallbackButton {
     }
 
     private void activateRefresh(AjaxRequestTarget target) {
-        if (!getTaskContainer().isRunning()) {
-            if (getBehaviors(RefreshBehavior.class).size() > 0) {
-                refreshBehavior.stop(target);
-            }
-        } else if (getBehaviors(RefreshBehavior.class).size() == 0) {
+        if (getBehaviors(RefreshBehavior.class).size() == 0) {
             add(refreshBehavior);
         } else {
             refreshBehavior.restart(target);

--- a/async-tasks-parent/async-tasks-impl/src/main/java/org/wicketstuff/async/components/ProgressButton.java
+++ b/async-tasks-parent/async-tasks-impl/src/main/java/org/wicketstuff/async/components/ProgressButton.java
@@ -201,9 +201,9 @@ public class ProgressButton extends AjaxFallbackButton {
     }
 
     private class RefreshBehavior extends AbstractAjaxTimerBehavior {
-        private boolean bound = false;
+        private boolean binded = false;
 
-        public RefreshBehavior(Duration updateInterval) {
+		public RefreshBehavior(Duration updateInterval) {
             super(updateInterval);
         }
 
@@ -223,22 +223,21 @@ public class ProgressButton extends AjaxFallbackButton {
             // Again, skip the check for the component being enabled
             return !isStopped() && getComponent().findParent(Page.class) != null;
         }
-
         @Override
         protected void onBind() {
-            super.onBind();
-            bound = true;
+        	super.onBind();
+        	binded   = true;
         }
-
+        
         @Override
         protected void onUnbind() {
-            super.onUnbind();
-            bound = false;
+        	super.onUnbind();
+        	binded = false;
         }
-
+        
         public boolean isBinded() {
-            return bound;
-        }
+			return binded;
+		}
     }
 
     /**


### PR DESCRIPTION
Hi!

I recently adapted [raphw/wicket-async-task](https://github.com/raphw/wicket-async-task) so that it works with Wicket 8, but then learned that it is abandoned in favor of async-task in wicketstuff/core.

I see from your previous commits that you also had a problem with randomly failing tests. However, we came up with different solutions. Your solution check if `refreshBehavior` is bound before stopping it. My solution doesn't attempt to stop it on the `#onSubmit` event. (Because I assume it will be stopped by an `#refresh`-event anyway.)

I'm no Wicket expert, so I would love if you would look at my solution and see if it's wrong.