### PR TITLE
Deprecate wicketstuff lambda interfaces/models and add lambda components/behaviors

### DIFF
--- a/lambda-parent/lambda/pom.xml
+++ b/lambda-parent/lambda/pom.xml
@@ -19,6 +19,10 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.wicket</groupId>
+			<artifactId>wicket-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.wicket</groupId>
 			<artifactId>wicket-extensions</artifactId>
 		</dependency>
 		<dependency>

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/OptionalFunction.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/OptionalFunction.java
@@ -11,9 +11,12 @@ import java.util.Optional;
  *            - the type of the input to the function
  * @param <R>
  *            - the type of the result of the function
+ * @deprecated no direct replacement but use {@link org.apache.wicket.model.LambdaModel#of(org.apache.wicket.model.IModel, org.danekja.java.util.function.serializable.SerializableFunction, org.danekja.java.util.function.serializable.SerializableBiConsumer} instead           
  */
 public class OptionalFunction<T, R> implements SerializableFunction<T, R> {
 
+	private static final long serialVersionUID = 1L;
+	
 	private SerializableFunction<T, Optional<R>> opFunction;
 	private SerializableSupplier<R> defaultValueSupplier;
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableBiConsumer.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableBiConsumer.java
@@ -10,6 +10,7 @@ import java.util.function.BiConsumer;
  *            - the type of the first argument to the operation
  * @param <U>
  *            - the type of the second argument to the operation
+ * @deprecated Use {@link org.danekja.java.util.function.serializable.SerializableBiConsumer} instead
  */
 public interface SerializableBiConsumer<T, U> extends Serializable, BiConsumer<T, U> {
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableBiFunction.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableBiFunction.java
@@ -12,7 +12,7 @@ import java.util.function.BiFunction;
  *            - the type of the second argument to the function
  * @param <R>
  *            - the type of the result of the function
- * 
+ * @deprecated Use {@link org.danekja.java.util.function.serializable.SerializableBiFunction} instead
  */
 public interface SerializableBiFunction<T, U, R> extends BiFunction<T, U, R>, Serializable {
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableConsumer.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableConsumer.java
@@ -8,6 +8,8 @@ import java.util.function.Consumer;
  *
  * @param <T>
  *            - the type of the input to the operation
+ *            
+ * @deprecated Use {@link org.danekja.java.util.function.serializable.SerializableConsumer} instead           
  */
 public interface SerializableConsumer<T> extends Consumer<T>, Serializable {
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableFunction.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableFunction.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
  *            - the type of the input to the function
  * @param <R>
  *            - the type of the result of the function
+ * @deprecated Use {@link org.danekja.java.util.function.serializable.SerializableFunction} instead           
  */
 public interface SerializableFunction<T, R> extends Function<T, R>, Serializable {
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableSupplier.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableSupplier.java
@@ -8,6 +8,7 @@ import java.util.function.Supplier;
  *
  * @param <T>
  *            - the type of results supplied by this supplier
+ * @deprecated Use {@link org.danekja.java.util.function.serializable.SerializableSupplier} instead           
  */
 public interface SerializableSupplier<T> extends Supplier<T>, Serializable {
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/AbstractAjaxTimerBehavior.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/AbstractAjaxTimerBehavior.java
@@ -1,0 +1,66 @@
+package org.wicketstuff.lambda.ajax;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.util.time.Duration;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.ajax.AbstractAjaxTimerBehavior} that uses a lambda
+ * for event handling.
+ * 
+ * @see org.apache.wicket.ajax.AbstractAjaxTimerBehavior
+ */
+public class AbstractAjaxTimerBehavior extends org.apache.wicket.ajax.AbstractAjaxTimerBehavior {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> timerHandler;
+
+	/**
+	 * Construct.
+	 * 
+	 * @param updateInterval
+	 *            Duration between AJAX callbacks
+	 */
+	public AbstractAjaxTimerBehavior(Duration updateInterval) {
+		this(updateInterval, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param updateInterval
+	 *            Duration between AJAX callbacks
+	 * @param timerHandler
+	 *            handler to call when the timer fires
+	 * 
+	 */
+	public AbstractAjaxTimerBehavior(Duration updateInterval, SerializableConsumer<AjaxRequestTarget> timerHandler) {
+		super(updateInterval);
+		this.timerHandler = timerHandler;
+	}
+
+	/**
+	 * Sets the handler to call when the timer fires.
+	 * 
+	 * @param timerHandler
+	 *            handler to call when the timer fires
+	 * @return this
+	 */
+	public AbstractAjaxTimerBehavior timerHandler(SerializableConsumer<AjaxRequestTarget> timerHandler) {
+		this.timerHandler = timerHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onTimer(AjaxRequestTarget target) {
+		if (timerHandler != null) {
+			timerHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("timerHandler not specified");
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/AjaxClientInfoBehavior.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/AjaxClientInfoBehavior.java
@@ -1,0 +1,89 @@
+package org.wicketstuff.lambda.ajax;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.protocol.http.request.WebClientInfo;
+import org.apache.wicket.util.time.Duration;
+import org.danekja.java.util.function.serializable.SerializableBiConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.ajax.AjaxClientInfoBehavior} that uses a lambda for
+ * event handling.
+ * 
+ * @see org.apache.wicket.ajax.AjaxClientInfoBehavior
+ */
+public class AjaxClientInfoBehavior extends org.apache.wicket.ajax.AjaxClientInfoBehavior {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableBiConsumer<AjaxRequestTarget, WebClientInfo> clientInfoHandler;
+
+	/**
+	 * Constructor.
+	 *
+	 * Auto fires after 50 millis.
+	 */
+	public AjaxClientInfoBehavior() {
+		this(null, null);
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * Auto fires after 50 millis.
+	 * 
+	 * @param clientInfoHandler
+	 *            handler to call to process the {@link WebClientInfo} data
+	 */
+	public AjaxClientInfoBehavior(SerializableBiConsumer<AjaxRequestTarget, WebClientInfo> clientInfoHandler) {
+		this(null, clientInfoHandler);
+	}
+
+	/**
+	 * Constructor. Auto fires after {@code duration}.
+	 * 
+	 * @param duration
+	 *            the duration of the client info behavior
+	 */
+	public AjaxClientInfoBehavior(Duration duration) {
+		this(duration, null);
+	}
+
+	/**
+	 * Constructor. Auto fires after {@code duration}.
+	 * 
+	 * @param duration
+	 *            the duration of the client info behavior
+	 * @param clientInfoHandler
+	 *            handler to process the {@link WebClientInfo} data
+	 */
+	public AjaxClientInfoBehavior(Duration duration,
+			SerializableBiConsumer<AjaxRequestTarget, WebClientInfo> clientInfoHandler) {
+		super(duration);
+		this.clientInfoHandler = clientInfoHandler;
+	}
+
+	/**
+	 * Sets the handler to deal with the {@link WebClientInfo} data
+	 * 
+	 * @param duration
+	 *            handler to process the {@link WebClientInfo} data
+	 * @return this
+	 */
+	public AjaxClientInfoBehavior clientInfoHandler(
+			SerializableBiConsumer<AjaxRequestTarget, WebClientInfo> clientInfoHandler) {
+		this.clientInfoHandler = clientInfoHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onClientInfo(AjaxRequestTarget target, WebClientInfo clientInfo) {
+		if (clientInfoHandler != null) {
+			clientInfoHandler.accept(target, clientInfo);
+		} else {
+			throw new WicketRuntimeException("clientInfoHandler not specified");
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/AjaxEventBehavior.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/AjaxEventBehavior.java
@@ -1,0 +1,64 @@
+package org.wicketstuff.lambda.ajax;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.ajax.AjaxEventBehavior} that uses a lambda for event
+ * handling.
+ *
+ * @see org.apache.wicket.ajax.AjaxEventBehavior
+ */
+public class AjaxEventBehavior extends org.apache.wicket.ajax.AjaxEventBehavior {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> eventHandler;
+
+	/**
+	 * Construct.
+	 * 
+	 * @param event
+	 *            the event this behavior will be attached to
+	 */
+	public AjaxEventBehavior(String event) {
+		this(event, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param event
+	 *            the event this behavior will be attached to
+	 * @param eventHandler
+	 *            handler to call when the given ajax event fires
+	 */
+	public AjaxEventBehavior(String event, SerializableConsumer<AjaxRequestTarget> eventHandler) {
+		super(event);
+		this.eventHandler = eventHandler;
+	}
+
+	/**
+	 * Sets the handler to call when when the given ajax event fires
+	 * 
+	 * @param eventHandler
+	 *            handler to call when when the given ajax event fires
+	 * @return this
+	 */
+	public AjaxEventBehavior eventHandler(SerializableConsumer<AjaxRequestTarget> eventHandler) {
+		this.eventHandler = eventHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onEvent(AjaxRequestTarget target) {
+		if (eventHandler != null) {
+			eventHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("eventHandler not specified");
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/AjaxNewWindowNotifyingBehavior.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/AjaxNewWindowNotifyingBehavior.java
@@ -1,0 +1,81 @@
+package org.wicketstuff.lambda.ajax;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.ajax.AjaxNewWindowNotifyingBehavior} that uses a
+ * lambda for event handling.
+ *
+ * @see org.apache.wicket.ajax.AjaxNewWindowNotifyingBehavior
+ */
+public class AjaxNewWindowNotifyingBehavior extends org.apache.wicket.ajax.AjaxNewWindowNotifyingBehavior {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> newWindowHandler;
+
+	/**
+	 * Constructor.
+	 */
+	public AjaxNewWindowNotifyingBehavior() {
+		super();
+	}
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param newWindowHandler
+	 *            handler to call when the new window is detected
+	 */
+	public AjaxNewWindowNotifyingBehavior(SerializableConsumer<AjaxRequestTarget> newWindowHandler) {
+		this(null, newWindowHandler);
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param windowName
+	 *            the custom name to use for the page's window
+	 */
+	public AjaxNewWindowNotifyingBehavior(String windowName) {
+		this(windowName, null);
+	}
+
+	/**
+	 * Constructor.
+	 *
+	 * @param windowName
+	 *            the custom name to use for the page's window
+	 * @param newWindowHandler
+	 *            handler to call when the new window is detected
+	 */
+	public AjaxNewWindowNotifyingBehavior(String windowName, SerializableConsumer<AjaxRequestTarget> newWindowHandler) {
+		super(windowName);
+		this.newWindowHandler = newWindowHandler;
+	}
+
+	/**
+	 * Sets the handler to call when the new window is detected.
+	 * 
+	 * @param newWindowHandler
+	 *            handler to call when the new window is detected
+	 * @return this
+	 */
+	public AjaxNewWindowNotifyingBehavior newWindowHandler(SerializableConsumer<AjaxRequestTarget> newWindowHandler) {
+		this.newWindowHandler = newWindowHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onNewWindow(AjaxRequestTarget target) {
+		if (newWindowHandler != null) {
+			newWindowHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("newWindowHandler not specified");
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/AjaxSelfUpdatingTimerBehavior.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/AjaxSelfUpdatingTimerBehavior.java
@@ -1,0 +1,66 @@
+package org.wicketstuff.lambda.ajax;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.util.time.Duration;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.ajax.AjaxSelfUpdatingTimerBehavior} that uses a
+ * lambda for event handling.
+ * 
+ * @see org.apache.wicket.ajax.AjaxSelfUpdatingTimerBehavior
+ */
+public class AjaxSelfUpdatingTimerBehavior extends org.apache.wicket.ajax.AjaxSelfUpdatingTimerBehavior {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> postProcessHandler;
+
+	/**
+	 * Construct.
+	 * 
+	 * @param updateInterval
+	 *            Duration between AJAX callbacks
+	 */
+	public AjaxSelfUpdatingTimerBehavior(Duration updateInterval) {
+		this(updateInterval, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param updateInterval
+	 *            Duration between AJAX callbacks
+	 * @param postProcessHandler
+	 *            handler to call to process the AJAX callback
+	 */
+	public AjaxSelfUpdatingTimerBehavior(Duration updateInterval,
+			SerializableConsumer<AjaxRequestTarget> postProcessHandler) {
+		super(updateInterval);
+		this.postProcessHandler = postProcessHandler;
+	}
+
+	/**
+	 * Sets the handler to call to process the AJAX callback.
+	 * 
+	 * @param postProcessHandler handler to call to process the AJAX callback
+	 * @return this 
+	 */
+	public AjaxSelfUpdatingTimerBehavior postProcessHandler(
+			SerializableConsumer<AjaxRequestTarget> postProcessHandler) {
+		this.postProcessHandler = postProcessHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onPostProcessTarget(AjaxRequestTarget target) {
+		if (postProcessHandler != null) {
+			postProcessHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("postProcessHandler not specified");
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/form/AjaxFormChoiceComponentUpdatingBehavior.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/form/AjaxFormChoiceComponentUpdatingBehavior.java
@@ -1,0 +1,85 @@
+package org.wicketstuff.lambda.ajax.form;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.danekja.java.util.function.serializable.SerializableBiConsumer;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior}
+ * that uses lambdas for event handling.
+ *
+ * @see org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior
+ */
+public class AjaxFormChoiceComponentUpdatingBehavior
+		extends org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> updateHandler;
+	private SerializableBiConsumer<AjaxRequestTarget, RuntimeException> errorHandler;
+
+	/**
+	 * Construct.
+	 */
+	public AjaxFormChoiceComponentUpdatingBehavior() {
+		this(null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param updateHandler
+	 *            handler to call when the choice component value is updated
+	 */
+	public AjaxFormChoiceComponentUpdatingBehavior(SerializableConsumer<AjaxRequestTarget> updateHandler) {
+		super();
+		this.updateHandler = updateHandler;
+	}
+
+	/**
+	 * Sets the handler to call when the choice component is updated.
+	 * 
+	 * @param updateHandler
+	 *            handler to call when the choice component is updated
+	 * @return this
+	 */
+	public AjaxFormChoiceComponentUpdatingBehavior updateHandler(
+			SerializableConsumer<AjaxRequestTarget> updateHandler) {
+		this.updateHandler = updateHandler;
+		return this;
+	}
+
+	/**
+	 * Sets the handler to call when there is an error updating the choice component.
+	 * 
+	 * @param errorHandler
+	 *            handler to call when there is an error updating the choice component
+	 * @return this
+	 */
+	public AjaxFormChoiceComponentUpdatingBehavior errorHandler(
+			SerializableBiConsumer<AjaxRequestTarget, RuntimeException> errorHandler) {
+		this.errorHandler = errorHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onUpdate(AjaxRequestTarget target) {
+		if (updateHandler != null) {
+			updateHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("updateHandler not specified");
+		}
+	}
+
+	@Override
+	protected final void onError(AjaxRequestTarget target, RuntimeException e) {
+		if (errorHandler != null) {
+			errorHandler.accept(target, e);
+		} else {
+			super.onError(target, e);
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/form/AjaxFormComponentUpdatingBehavior.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/form/AjaxFormComponentUpdatingBehavior.java
@@ -1,0 +1,88 @@
+package org.wicketstuff.lambda.ajax.form;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.danekja.java.util.function.serializable.SerializableBiConsumer;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior} that
+ * uses lambdas for event handling.
+ * 
+ * @see org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior
+ */
+public class AjaxFormComponentUpdatingBehavior extends org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> updateHandler;
+	private SerializableBiConsumer<AjaxRequestTarget, RuntimeException> errorHandler;
+
+	/**
+	 * Construct.
+	 * 
+	 * @param event
+	 *            event to trigger this behavior
+	 */
+	public AjaxFormComponentUpdatingBehavior(String event) {
+		this(event, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param event
+	 *            event to trigger this behavior
+	 * @param updateHandler
+	 *            handler to call to process the update
+	 */
+	public AjaxFormComponentUpdatingBehavior(String event, SerializableConsumer<AjaxRequestTarget> updateHandler) {
+		super(event);
+		this.updateHandler = updateHandler;
+	}
+
+	/**
+	 * Sets the handler to call when a component is updated.
+	 * 
+	 * @param updateHandler
+	 *            handler to call to process the update
+	 * @return this
+	 */
+	public AjaxFormComponentUpdatingBehavior updateHandler(SerializableConsumer<AjaxRequestTarget> updateHandler) {
+		this.updateHandler = updateHandler;
+		return this;
+	}
+
+	/**
+	 * Sets the handler to call when an error occurs.
+	 * 
+	 * @param errorHandler
+	 *            handler to call to process the error
+	 * @return this
+	 */
+	public AjaxFormComponentUpdatingBehavior errorHandler(
+			SerializableBiConsumer<AjaxRequestTarget, RuntimeException> errorHandler) {
+		this.errorHandler = errorHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onUpdate(AjaxRequestTarget target) {
+		if (updateHandler != null) {
+			updateHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("updateHandler not specified");
+		}
+	}
+
+	@Override
+	protected final void onError(AjaxRequestTarget target, RuntimeException e) {
+		if (errorHandler != null) {
+			errorHandler.accept(target, e);
+		} else {
+			super.onError(target, e);
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/form/AjaxFormSubmitBehavior.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/form/AjaxFormSubmitBehavior.java
@@ -1,0 +1,86 @@
+package org.wicketstuff.lambda.ajax.form;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.ajax.form.AjaxFormSubmitBehavior} that uses lambdas
+ * for event handling.
+ * 
+ * @see org.apache.wicket.ajax.form.AjaxFormSubmitBehavior
+ */
+public class AjaxFormSubmitBehavior extends org.apache.wicket.ajax.form.AjaxFormSubmitBehavior {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> submitHandler;
+	private SerializableConsumer<AjaxRequestTarget> errorHandler;
+
+	/**
+	 * Constructor. This constructor can only be used when the component this
+	 * behavior is attached to is inside a form.
+	 * 
+	 * @param event
+	 *            javascript event this behavior is attached to, like onclick
+	 */
+	public AjaxFormSubmitBehavior(String event) {
+		this(event, null);
+	}
+
+	/**
+	 * Constructor. This constructor can only be used when the component this
+	 * behavior is attached to is inside a form.
+	 * 
+	 * @param event
+	 *            javascript event this behavior is attached to, like onclick
+	 * @param updateHandler
+	 *            handler to call to handle the submit
+	 */
+	public AjaxFormSubmitBehavior(String event, SerializableConsumer<AjaxRequestTarget> submitHandler) {
+		super(event);
+		this.submitHandler = submitHandler;
+	}
+
+	/**
+	 * Sets the handler to call on submit.
+	 * 
+	 * @param submitHandler
+	 *            handler to call to handle the submit
+	 * @return this
+	 */
+	public AjaxFormSubmitBehavior submitHandler(SerializableConsumer<AjaxRequestTarget> submitHandler) {
+		this.submitHandler = submitHandler;
+		return this;
+	}
+
+	/**
+	 * Sets the handler to call on error.
+	 * 
+	 * @param errorHandler
+	 *            handler to call to handle the error
+	 * @return this
+	 */
+	public AjaxFormSubmitBehavior errorHandler(SerializableConsumer<AjaxRequestTarget> errorHandler) {
+		this.errorHandler = errorHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onSubmit(AjaxRequestTarget target) {
+		if (submitHandler != null) {
+			submitHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("submitHandler not specified");
+		}
+	}
+
+	@Override
+	protected final void onError(AjaxRequestTarget target) {
+		if (errorHandler != null) {
+			errorHandler.accept(target);
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/form/OnChangeAjaxBehavior.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/form/OnChangeAjaxBehavior.java
@@ -1,0 +1,82 @@
+package org.wicketstuff.lambda.ajax.form;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.danekja.java.util.function.serializable.SerializableBiConsumer;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.ajax.form.OnChangeAjaxBehavior} that uses lambdas
+ * for event handling.
+ * 
+ * @see org.apache.wicket.ajax.form.OnChangeAjaxBehavior
+ */
+public class OnChangeAjaxBehavior extends org.apache.wicket.ajax.form.OnChangeAjaxBehavior {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> updateHandler;
+	private SerializableBiConsumer<AjaxRequestTarget, RuntimeException> errorHandler;
+
+	/**
+	 * Constructor.
+	 */
+	public OnChangeAjaxBehavior() {
+		this(null);
+	}
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param updateHandler
+	 *            handler to call to process the update
+	 */
+	public OnChangeAjaxBehavior(SerializableConsumer<AjaxRequestTarget> updateHandler) {
+		super();
+		this.updateHandler = updateHandler;
+	}
+
+	/**
+	 * Sets the handler to call on submit.
+	 * 
+	 * @param updateHandler
+	 *            handler to call to process the update
+	 * @return this
+	 */
+	public OnChangeAjaxBehavior updateHandler(SerializableConsumer<AjaxRequestTarget> updateHandler) {
+		this.updateHandler = updateHandler;
+		return this;
+	}
+
+	/**
+	 * Sets the handler to call on error.
+	 * 
+	 * @param errorHandler
+	 *            handler to call to process the error
+	 * @return this
+	 */
+	public OnChangeAjaxBehavior errorHandler(SerializableBiConsumer<AjaxRequestTarget, RuntimeException> errorHandler) {
+		this.errorHandler = errorHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onUpdate(AjaxRequestTarget target) {
+		if (updateHandler != null) {
+			updateHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("updateHandler not specified");
+		}
+	}
+
+	@Override
+	protected final void onError(AjaxRequestTarget target, RuntimeException e) {
+		if (errorHandler != null) {
+			errorHandler.accept(target, e);
+		} else {
+			super.onError(target, e);
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/AjaxFallbackLink.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/AjaxFallbackLink.java
@@ -1,0 +1,90 @@
+package org.wicketstuff.lambda.ajax.markup.html;
+
+import java.util.Optional;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.model.IModel;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of, and drop in replacement for,
+ * {@link org.apache.wicket.ajax.markup.html.AjaxFallbackLink} that uses a
+ * lambda for event handling.
+ * 
+ * @see org.apache.wicket.ajax.markup.html.AjaxFallbackLink
+ * @param <T>
+ *            type of the model for the link
+ */
+public class AjaxFallbackLink<T> extends org.apache.wicket.ajax.markup.html.AjaxFallbackLink<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<Optional<AjaxRequestTarget>> clickHandler;
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 */
+	public AjaxFallbackLink(String id) {
+		this(id, null, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param clickHandler
+	 *            handler to call to handle the click
+	 */
+	public AjaxFallbackLink(String id, SerializableConsumer<Optional<AjaxRequestTarget>> clickHandler) {
+		this(id, null, clickHandler);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param model
+	 */
+	public AjaxFallbackLink(String id, IModel<T> model) {
+		this(id, model, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param model
+	 * @param clickHandler
+	 *            handler to call to handle the click
+	 */
+	public AjaxFallbackLink(String id, IModel<T> model,
+			SerializableConsumer<Optional<AjaxRequestTarget>> clickHandler) {
+		super(id, model);
+		this.clickHandler = clickHandler;
+	}
+
+	/**
+	 * Sets the handler to call on click.
+	 * 
+	 * @param clickHandler
+	 *            handler to call to handle the click
+	 * @return this
+	 */
+	public AjaxFallbackLink<T> clickHandler(SerializableConsumer<Optional<AjaxRequestTarget>> clickHandler) {
+		this.clickHandler = clickHandler;
+		return this;
+	}
+
+	@Override
+	public final void onClick(Optional<AjaxRequestTarget> target) {
+		if (clickHandler != null) {
+			clickHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("clickHandler not specified");
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/AjaxLink.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/AjaxLink.java
@@ -1,0 +1,87 @@
+package org.wicketstuff.lambda.ajax.markup.html;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.model.IModel;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of, and drop in replacement for,
+ * {@link org.apache.wicket.ajax.markup.html.AjaxLink} that uses a lambda for
+ * event handling.
+ * 
+ * @see org.apache.wicket.ajax.markup.html.AjaxLink
+ * @param <T>
+ *            type of the model for the link
+ */
+public class AjaxLink<T> extends org.apache.wicket.ajax.markup.html.AjaxLink<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> clickHandler;
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 */
+	public AjaxLink(String id) {
+		this(id, null, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param clickHandler
+	 *            handler to call to handle the click
+	 */
+	public AjaxLink(String id, SerializableConsumer<AjaxRequestTarget> clickHandler) {
+		this(id, null, clickHandler);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param model
+	 */
+	public AjaxLink(String id, IModel<T> model) {
+		this(id, model, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param model
+	 * @param clickHandler
+	 *            handler to call to handle the click
+	 */
+	public AjaxLink(String id, IModel<T> model, SerializableConsumer<AjaxRequestTarget> clickHandler) {
+		super(id, model);
+		this.clickHandler = clickHandler;
+	}
+
+	/**
+	 * Sets the handler to call on click.
+	 * 
+	 * @param clickHandler
+	 *            handler to call to handle the click
+	 * @return this
+	 */
+	public AjaxLink<T> clickHandler(SerializableConsumer<AjaxRequestTarget> clickHandler) {
+		this.clickHandler = clickHandler;
+		return this;
+	}
+
+	@Override
+	public final void onClick(AjaxRequestTarget target) {
+		if (clickHandler != null) {
+			clickHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("clickHandler not specified");
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/IndicatingAjaxButton.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/IndicatingAjaxButton.java
@@ -1,0 +1,107 @@
+package org.wicketstuff.lambda.ajax.markup.html;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.model.IModel;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of, and drop in replacement for,
+ * {@link org.apache.wicket.ajax.markup.html.IndicatingAjaxButton} that uses
+ * lambdas for event handling.
+ * 
+ * @see org.apache.wicket.ajax.markup.html.IndicatingAjaxButton
+ * @param <T>
+ *            type of the model for the link
+ */
+public class IndicatingAjaxButton extends org.apache.wicket.extensions.ajax.markup.html.IndicatingAjaxButton {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> submitHandler;
+	private SerializableConsumer<AjaxRequestTarget> errorHandler;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param id
+	 */
+	public IndicatingAjaxButton(String id) {
+		this(id, null, null);
+	}
+
+	/**
+	 * 
+	 * Constructor
+	 * 
+	 * @param id
+	 * @param form
+	 */
+	public IndicatingAjaxButton(String id, Form<?> form) {
+		this(id, null, form);
+	}
+
+	/**
+	 * Constructor
+	 * 
+	 * @param id
+	 * @param model
+	 *            model used to set <code>value</code> markup attribute
+	 */
+	public IndicatingAjaxButton(String id, IModel<String> model) {
+		this(id, model, null);
+	}
+
+	/**
+	 * Constructor
+	 * 
+	 * @param id
+	 * @param model
+	 * @param form
+	 */
+	public IndicatingAjaxButton(String id, IModel<String> model, Form<?> form) {
+		super(id, model, form);
+	}
+
+	/**
+	 * Sets the handler to call on submit.
+	 * 
+	 * @param submitHandler
+	 *            handler to call to process the submit
+	 * @return this
+	 */
+	public IndicatingAjaxButton submitHandler(SerializableConsumer<AjaxRequestTarget> submitHandler) {
+		this.submitHandler = submitHandler;
+		return this;
+	}
+
+	/**
+	 * Sets the handler to call on error.
+	 * 
+	 * @param errorHandler
+	 *            handler to call to process the error
+	 * @return this
+	 */
+	public IndicatingAjaxButton errorHandler(SerializableConsumer<AjaxRequestTarget> errorHandler) {
+		this.errorHandler = errorHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onSubmit(AjaxRequestTarget target) {
+		if (submitHandler != null) {
+			submitHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("submitHandler not specified");
+		}
+	}
+
+	@Override
+	protected final void onError(AjaxRequestTarget target) {
+		if (errorHandler != null) {
+			errorHandler.accept(target);
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/form/AjaxButton.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/form/AjaxButton.java
@@ -1,0 +1,107 @@
+package org.wicketstuff.lambda.ajax.markup.html.form;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.model.IModel;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of, and drop in replacement for,
+ * {@link org.apache.wicket.ajax.markup.html.form.AjaxButton} that uses lambdas
+ * for event handling.
+ * 
+ * @see org.apache.wicket.ajax.markup.html.form.AjaxButton
+ */
+public class AjaxButton extends org.apache.wicket.ajax.markup.html.form.AjaxButton {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> submitHandler;
+	private SerializableConsumer<AjaxRequestTarget> errorHandler;
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 */
+	public AjaxButton(String id) {
+		this(id, null, null);
+	}
+
+	/**
+	 * 
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param form
+	 */
+	public AjaxButton(String id, Form<?> form) {
+		this(id, null, form);
+	}
+
+	/**
+	 * 
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param model
+	 *            model used to set <code>value</code> markup attribute
+	 */
+	public AjaxButton(String id, IModel<String> model) {
+		this(id, model, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param model
+	 *            model used to set <code>value</code> markup attribute
+	 * @param form
+	 */
+	public AjaxButton(String id, IModel<String> model, Form<?> form) {
+		super(id, model, form);
+	}
+
+	/**
+	 * Sets the handler to call on submit.
+	 * 
+	 * @param submitHandler
+	 *            handler to call to process the submit
+	 * @return this
+	 */
+	public AjaxButton submitHandler(SerializableConsumer<AjaxRequestTarget> submitHandler) {
+		this.submitHandler = submitHandler;
+		return this;
+	}
+
+	/**
+	 * Sets the handler to call on error.
+	 * 
+	 * @param errorHandler
+	 *            handler to call to process the error
+	 * @return this
+	 */
+	public AjaxButton errorHandler(SerializableConsumer<AjaxRequestTarget> errorHandler) {
+		this.errorHandler = errorHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onSubmit(AjaxRequestTarget target) {
+		if (submitHandler != null) {
+			submitHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("submitHandler not specified");
+		}
+	}
+
+	@Override
+	protected final void onError(AjaxRequestTarget target) {
+		if (errorHandler != null) {
+			errorHandler.accept(target);
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/form/AjaxCheckBox.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/form/AjaxCheckBox.java
@@ -1,0 +1,85 @@
+package org.wicketstuff.lambda.ajax.markup.html.form;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.model.IModel;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of, and drop in replacement for,
+ * {@link org.apache.wicket.ajax.markup.html.form.AjaxCheckBox} that uses
+ * lambdas for event handling.
+ * 
+ * @see org.apache.wicket.ajax.markup.html.form.AjaxCheckBox
+ */
+public class AjaxCheckBox extends org.apache.wicket.ajax.markup.html.form.AjaxCheckBox {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> updateHandler;
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 */
+	public AjaxCheckBox(String id) {
+		this(id, null, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param updateHandler
+	 *            handler to call to process the update
+	 */
+	public AjaxCheckBox(String id, SerializableConsumer<AjaxRequestTarget> updateHandler) {
+		this(id, null, updateHandler);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param model
+	 */
+	public AjaxCheckBox(String id, IModel<Boolean> model) {
+		this(id, model, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param model
+	 * @param updateHandler
+	 *            handler to call to process the update
+	 */
+	public AjaxCheckBox(String id, IModel<Boolean> model, SerializableConsumer<AjaxRequestTarget> updateHandler) {
+		super(id, model);
+		this.updateHandler = updateHandler;
+	}
+
+	/**
+	 * Sets the handler to call on update.
+	 * 
+	 * @param updateHandler
+	 *            handler to call to process the update
+	 * @return this
+	 */
+	public AjaxCheckBox updateHandler(SerializableConsumer<AjaxRequestTarget> updateHandler) {
+		this.updateHandler = updateHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onUpdate(AjaxRequestTarget target) {
+		if (updateHandler != null) {
+			updateHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("updateHandler not specified");
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/form/AjaxSubmitLink.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/form/AjaxSubmitLink.java
@@ -1,0 +1,81 @@
+package org.wicketstuff.lambda.ajax.markup.html.form;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.Form;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink} that uses
+ * lambdas for event handling.
+ * 
+ * @see org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink
+ */
+public class AjaxSubmitLink extends org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<AjaxRequestTarget> submitHandler;
+	private SerializableConsumer<AjaxRequestTarget> errorHandler;
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 */
+	public AjaxSubmitLink(String id) {
+		this(id, null);
+	}
+
+	/**
+	 * Construct.
+	 * 
+	 * @param id
+	 * @param form
+	 */
+	public AjaxSubmitLink(String id, Form<?> form) {
+		super(id, form);
+	}
+
+	/**
+	 * Sets the handler to call on submit.
+	 * 
+	 * @param submitHandler
+	 *            handler to call to process the submit
+	 * @return this
+	 */
+	public AjaxSubmitLink submitHandler(SerializableConsumer<AjaxRequestTarget> submitHandler) {
+		this.submitHandler = submitHandler;
+		return this;
+	}
+
+	/**
+	 * Sets the handler to call on error.
+	 * 
+	 * @param errorHandler
+	 *            handler to call to process the error
+	 * @return this
+	 */
+	public AjaxSubmitLink errorHandler(SerializableConsumer<AjaxRequestTarget> errorHandler) {
+		this.errorHandler = errorHandler;
+		return this;
+	}
+
+	@Override
+	protected final void onSubmit(AjaxRequestTarget target) {
+		if (submitHandler != null) {
+			submitHandler.accept(target);
+		} else {
+			throw new WicketRuntimeException("submitHandler not specified");
+		}
+	}
+
+	@Override
+	protected final void onError(AjaxRequestTarget target) {
+		if (errorHandler != null) {
+			errorHandler.accept(target);
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/form/Button.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/form/Button.java
@@ -1,0 +1,91 @@
+package org.wicketstuff.lambda.ajax.markup.html.form;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.model.IModel;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.ajax.markup.html.form.Button} that uses lambdas for
+ * event handling.
+ * 
+ * @see org.apache.wicket.ajax.markup.html.form.Button
+ */
+public class Button extends org.apache.wicket.markup.html.form.Button {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<Button> submitHandler;
+	private SerializableConsumer<Button> errorHandler;
+
+	/**
+	 * Constructor without a model. Buttons without models leave the markup
+	 * attribute &quot;value&quot;. Provide a model if you want to set the
+	 * button's label dynamically.
+	 * 
+	 * @see org.apache.wicket.Component#Component(String)
+	 */
+	public Button(String id) {
+		super(id);
+	}
+
+	/**
+	 * Constructor taking an model for rendering the 'label' of the button (the
+	 * value attribute of the input/button tag). Use a
+	 * {@link org.apache.wicket.model.StringResourceModel} for a localized
+	 * value.
+	 * 
+	 * @param id
+	 *            Component id
+	 * @param model
+	 *            The model property is used to set the &quot;value&quot;
+	 *            attribute. It will thus be the label of the button that shows
+	 *            up for end users. If you want the attribute to keep it's
+	 *            markup attribute value, don't provide a model, or let it
+	 *            return an empty string.
+	 */
+	public Button(String id, IModel<String> model) {
+		super(id, model);
+	}
+
+	/**
+	 * Sets the handler to call on submit.
+	 * 
+	 * @param submitHandler
+	 *            handler to call to process the submit
+	 * @return this
+	 */
+	public Button submitHandler(SerializableConsumer<Button> submitHandler) {
+		this.submitHandler = submitHandler;
+		return this;
+	}
+
+	/**
+	 * Sets the handler to call on error.
+	 * 
+	 * @param errorHandler
+	 *            handler to call to process the error
+	 * @return this
+	 */
+	public Button errorHandler(SerializableConsumer<Button> errorHandler) {
+		this.errorHandler = errorHandler;
+		return this;
+	}
+
+	@Override
+	public final void onSubmit() {
+		if (submitHandler != null) {
+			submitHandler.accept(this);
+		} else {
+			throw new WicketRuntimeException("submitHandler not specified");
+		}
+	}
+
+	@Override
+	public final void onError() {
+		if (errorHandler != null) {
+			errorHandler.accept(this);
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/list/ListView.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/ajax/markup/html/list/ListView.java
@@ -1,0 +1,87 @@
+package org.wicketstuff.lambda.ajax.markup.html.list;
+
+import java.util.List;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.markup.html.list.ListView} that uses lambdas for
+ * event handling.
+ * 
+ * @see org.apache.wicket.markup.html.list.ListView
+ */
+public class ListView<T> extends org.apache.wicket.markup.html.list.ListView<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<ListItem<T>> populateItemHandler;
+
+	/**
+	 * @see org.apache.wicket.Component#Component(String)
+	 */
+	public ListView(String id) {
+		this(id, null, null);
+	}
+
+	/**
+	 * @param id
+	 *            See Component
+	 * @param list
+	 *            List to cast to Serializable
+	 * @see org.apache.wicket.Component#Component(String, IModel)
+	 */
+	public ListView(String id, List<T> list) {
+		this(id, Model.ofList(list), null);
+	}
+
+	/**
+	 * @param id
+	 *            component id
+	 * @param model
+	 *            model containing a list of
+	 * @see org.apache.wicket.Component#Component(String, IModel)
+	 */
+	public ListView(String id, IModel<? extends List<T>> model) {
+		this(id, model, null);
+	}
+
+	/**
+	 * @param id
+	 *            component id
+	 * @param model
+	 *            model containing a list of
+	 * @param populateItemHandler
+	 *            handler to call to populate the list view
+	 */
+	public ListView(String id, IModel<? extends List<T>> model, SerializableConsumer<ListItem<T>> populateItemHandler) {
+		super(id, model);
+		this.populateItemHandler = populateItemHandler;
+	}
+
+	/**
+	 * Sets the handler to call to populate the list view
+	 * 
+	 * @param populateItemHandler
+	 *            handler to call to populate the list view
+	 * @return thi
+	 */
+	public ListView<T> populateItemHandler(SerializableConsumer<ListItem<T>> populateItemHandler) {
+		this.populateItemHandler = populateItemHandler;
+		return this;
+	}
+
+	@Override
+	protected final void populateItem(ListItem<T> item) {
+		if (populateItemHandler != null) {
+			populateItemHandler.accept(item);
+		} else {
+			throw new WicketRuntimeException("populateItemHandler not specified");
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/behavior/AttributeHandler.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/behavior/AttributeHandler.java
@@ -1,0 +1,41 @@
+package org.wicketstuff.lambda.behavior;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.ComponentTag;
+import org.apache.wicket.markup.parser.XmlTag.TagType;
+import org.danekja.java.util.function.serializable.SerializableBiConsumer;
+import org.danekja.java.util.function.serializable.SerializableFunction;
+
+/**
+ * {@link SerializableBiConsumer} to use with {@link Behavior} for
+ * setting/changing an attribute value.
+ */
+public class AttributeHandler implements SerializableBiConsumer<Component, ComponentTag> {
+
+	private static final long serialVersionUID = 1L;
+
+	private String name;
+	private SerializableFunction<String, CharSequence> attributeHandler;
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param name
+	 *            the name of the attribute
+	 * @param attributeHandler
+	 *            handler to call to set/replace the attribute value
+	 */
+	public AttributeHandler(String name, SerializableFunction<String, CharSequence> attributeHandler) {
+		this.name = name;
+		this.attributeHandler = attributeHandler;
+	}
+
+	@Override
+	public void accept(Component component, ComponentTag tag) {
+		if (tag.getType() != TagType.CLOSE) {
+			String oldValue = tag.getAttribute(name);
+			tag.put(name, attributeHandler.apply(oldValue));
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/behavior/Behavior.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/behavior/Behavior.java
@@ -1,0 +1,60 @@
+package org.wicketstuff.lambda.behavior;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.markup.ComponentTag;
+import org.danekja.java.util.function.serializable.SerializableBiConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.behavior.Behavior} that uses a lambda for event
+ * handling.
+ * 
+ * @see org.apache.wicket.behavior.Behavior
+ */
+public class Behavior extends org.apache.wicket.behavior.Behavior {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableBiConsumer<Component, ComponentTag> componentTagHandler;
+
+	/**
+	 * Constructor
+	 */
+	public Behavior() {
+		this(null);
+	}
+
+	/**
+	 * Constructor
+	 * 
+	 * @param componentTagHandler
+	 *            handler to call to process the tag
+	 */
+	public Behavior(SerializableBiConsumer<Component, ComponentTag> componentTagHandler) {
+		super();
+		this.componentTagHandler = componentTagHandler;
+	}
+
+	/**
+	 * Sets the handler to call to process the tag.
+	 * 
+	 * @param componentTagHandler
+	 *            handler to call to process the tag
+	 * @return this
+	 */
+	public Behavior componentTagHandler(SerializableBiConsumer<Component, ComponentTag> componentTagHandler) {
+		this.componentTagHandler = componentTagHandler;
+		return this;
+	}
+
+	@Override
+	public final void onComponentTag(Component component, ComponentTag tag) {
+		if (componentTagHandler != null) {
+			componentTagHandler.accept(component, tag);
+		} else {
+			throw new WicketRuntimeException("componentTagHandler not specified");
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/markup/html/link/Link.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/markup/html/link/Link.java
@@ -1,0 +1,82 @@
+package org.wicketstuff.lambda.markup.html.link;
+
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.model.IModel;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
+/**
+ * Subclass of and drop in replacement for
+ * {@link org.apache.wicket.markup.html.link.Link} that uses a lambda for event
+ * handling.
+ * 
+ * @see org.apache.wicket.markup.html.link.Link
+ */
+public class Link<T> extends org.apache.wicket.markup.html.link.Link<T> {
+
+	private static final long serialVersionUID = 1L;
+
+	private SerializableConsumer<Link<T>> clickHandler;
+
+	/**
+	 * @see org.apache.wicket.Component#Component(String)
+	 */
+	public Link(String id) {
+		this(id, null, null);
+	}
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param id
+	 * @param clickHandler
+	 *            handler to call on click
+	 * @see org.apache.wicket.Component#Component(String)
+	 */
+	public Link(String id, SerializableConsumer<Link<T>> clickHandler) {
+		this(id, null, clickHandler);
+	}
+
+	/**
+	 * @param id
+	 * @param model
+	 * @see org.apache.wicket.Component#Component(String, IModel)
+	 */
+	public Link(String id, IModel<T> model) {
+		this(id, model, null);
+	}
+
+	/**
+	 * Constructor.
+	 * 
+	 * @param id
+	 * @param model
+	 * @param clickHandler
+	 *            handler to call to process the click
+	 */
+	public Link(String id, IModel<T> model, SerializableConsumer<Link<T>> clickHandler) {
+		super(id, model);
+		this.clickHandler = clickHandler;
+	}
+
+	/**
+	 * Sets the handler to call on click.
+	 * 
+	 * @param clickHandler
+	 *            handler to call to process the click
+	 * @return this
+	 */
+	public Link<T> clickHandler(SerializableConsumer<Link<T>> clickHandler) {
+		this.clickHandler = clickHandler;
+		return this;
+	}
+
+	@Override
+	public final void onClick() {
+		if (clickHandler != null) {
+			clickHandler.accept(this);
+		} else {
+			throw new WicketRuntimeException("clickHandler not specified");
+		}
+	}
+
+}

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/model/LambdaModel.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/model/LambdaModel.java
@@ -21,8 +21,11 @@ import org.wicketstuff.lambda.SerializableFunction;
  *            - type of the wrapped {@link IModel}
  * @param <R>
  *            - type of the {@link LambdaModel}
+ * @deprecated Use {@link org.apache.wicket.model.LambdaModel} and {@link LoadableDetachableModel#of(org.danekja.java.util.function.serializable.SerializableSupplier)} instead           
  */
 public class LambdaModel<T, R> extends LoadableDetachableModel<R> {
+	
+	private static final long serialVersionUID = 1L;
 	
 	private IModel<T> wrappedModel;
 	private SerializableFunction<T, R> loadHandler;

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/model/SupplierModel.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/model/SupplierModel.java
@@ -8,9 +8,12 @@ import org.wicketstuff.lambda.SerializableSupplier;
  *
  * @param <T>
  *            - type of the model object
+ * @deprecated Use {@link LambdaModel} or {@link LoadableDetachableModel#of(org.danekja.java.util.function.serializable.SerializableSupplier)} instead           
  */
 public class SupplierModel<T> extends LoadableDetachableModel<T> {
 
+	private static final long serialVersionUID = 1L;
+	
 	/*
 	 * Supplier that supplies the value of the model.
 	 */

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/table/FunctionColumn.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/table/FunctionColumn.java
@@ -4,6 +4,7 @@ import java.util.function.Function;
 
 import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.AbstractColumn;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.LambdaColumn;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.model.IModel;
@@ -20,6 +21,8 @@ import org.wicketstuff.lambda.model.LambdaModel;
  *            - the type of the sort property
  * @param <R>
  *            - type type of the cell
+ *            
+ * @deprecated use {@link LambdaColumn} instead
  */
 public class FunctionColumn<T, S, R> extends AbstractColumn<T, S> {
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/table/FunctionColumn.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/table/FunctionColumn.java
@@ -26,6 +26,8 @@ import org.wicketstuff.lambda.model.LambdaModel;
  */
 public class FunctionColumn<T, S, R> extends AbstractColumn<T, S> {
 
+	private static final long serialVersionUID = 1L;
+	
 	/*
 	 * Function that generates the model of the cell from the model of the row.
 	 */


### PR DESCRIPTION
Deprecated the lambda-related functionality that is now implemented in Wicket itself.

Further, as per a discussion on the wicket-dev mailing list [1], it was suggested that components/behaviors with built in lambda functionality be implemented separately instead of adding the functionality directly to the components/behaviors in Wicket itself.   

It was further argued that using static factory methods to create "lambda-enabled" components and behaviors was not very flexible because the class could not be overridden.

This is a (hopefully) straightforward implementation (sub-classing) of adding lambda handlers to components and behaviors that have onXXX methods.  The implementation takes a lambda as a constructor parameter or setter, and uses the lambda to implement the onXXX methods while marking the onXXX methods as final.

Since these are "regular" classes as opposed to static factory methods, it is possible to (anonymously) sub-class them to provide other functionality (e.g., overriding onConfigure).  There should be a class that can be used to accomplish the functionality for each static factory method in org.apache.wicket.lambda.Lambdas.

The names of these "lambda-enabled" classes are exactly the same as the "regular" classes in Wicket itself (e.g., AjaxLink).  The difference is the package the classes exist in -- s/org.apache.wicket/org.wicketstuff.lambda/.  This should make it easy to find/replace one with the other.

[1] http://mail-archives.apache.org/mod_mbox/wicket-dev/201702.mbox/%3C839fe7c0-8e79-cc9d-aa51-03e01be85473@meiers.net%3E