### PR TITLE
Added @deprecated and @see Javadocs for superceded functionality.

### DIFF
--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/OptionalFunction.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/OptionalFunction.java
@@ -11,9 +11,12 @@ import java.util.Optional;
  *            - the type of the input to the function
  * @param <R>
  *            - the type of the result of the function
+ * @deprecated no direct replacement but use {@link org.apache.wicket.model.LambdaModel#of(org.apache.wicket.model.IModel, org.danekja.java.util.function.serializable.SerializableFunction, org.danekja.java.util.function.serializable.SerializableBiConsumer} instead           
  */
 public class OptionalFunction<T, R> implements SerializableFunction<T, R> {
 
+	private static final long serialVersionUID = 1L;
+	
 	private SerializableFunction<T, Optional<R>> opFunction;
 	private SerializableSupplier<R> defaultValueSupplier;
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableBiConsumer.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableBiConsumer.java
@@ -10,6 +10,7 @@ import java.util.function.BiConsumer;
  *            - the type of the first argument to the operation
  * @param <U>
  *            - the type of the second argument to the operation
+ * @deprecated Use {@link org.danekja.java.util.function.serializable.SerializableBiConsumer} instead
  */
 public interface SerializableBiConsumer<T, U> extends Serializable, BiConsumer<T, U> {
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableBiFunction.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableBiFunction.java
@@ -12,7 +12,7 @@ import java.util.function.BiFunction;
  *            - the type of the second argument to the function
  * @param <R>
  *            - the type of the result of the function
- * 
+ * @deprecated Use {@link org.danekja.java.util.function.serializable.SerializableBiFunction} instead
  */
 public interface SerializableBiFunction<T, U, R> extends BiFunction<T, U, R>, Serializable {
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableConsumer.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableConsumer.java
@@ -8,6 +8,8 @@ import java.util.function.Consumer;
  *
  * @param <T>
  *            - the type of the input to the operation
+ *            
+ * @deprecated Use {@link org.danekja.java.util.function.serializable.SerializableConsumer} instead           
  */
 public interface SerializableConsumer<T> extends Consumer<T>, Serializable {
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableFunction.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableFunction.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
  *            - the type of the input to the function
  * @param <R>
  *            - the type of the result of the function
+ * @deprecated Use {@link org.danekja.java.util.function.serializable.SerializableFunction} instead           
  */
 public interface SerializableFunction<T, R> extends Function<T, R>, Serializable {
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableSupplier.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/SerializableSupplier.java
@@ -8,6 +8,7 @@ import java.util.function.Supplier;
  *
  * @param <T>
  *            - the type of results supplied by this supplier
+ * @deprecated Use {@link org.danekja.java.util.function.serializable.SerializableSupplier} instead           
  */
 public interface SerializableSupplier<T> extends Supplier<T>, Serializable {
 

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/model/LambdaModel.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/model/LambdaModel.java
@@ -21,8 +21,11 @@ import org.wicketstuff.lambda.SerializableFunction;
  *            - type of the wrapped {@link IModel}
  * @param <R>
  *            - type of the {@link LambdaModel}
+ * @deprecated Use {@link org.apache.wicket.model.LambdaModel} and {@link LoadableDetachableModel#of(org.danekja.java.util.function.serializable.SerializableSupplier)} instead           
  */
 public class LambdaModel<T, R> extends LoadableDetachableModel<R> {
+	
+	private static final long serialVersionUID = 1L;
 	
 	private IModel<T> wrappedModel;
 	private SerializableFunction<T, R> loadHandler;

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/model/SupplierModel.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/model/SupplierModel.java
@@ -8,9 +8,12 @@ import org.wicketstuff.lambda.SerializableSupplier;
  *
  * @param <T>
  *            - type of the model object
+ * @deprecated Use {@link LambdaModel} or {@link LoadableDetachableModel#of(org.danekja.java.util.function.serializable.SerializableSupplier)} instead           
  */
 public class SupplierModel<T> extends LoadableDetachableModel<T> {
 
+	private static final long serialVersionUID = 1L;
+	
 	/*
 	 * Supplier that supplies the value of the model.
 	 */

--- a/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/table/FunctionColumn.java
+++ b/lambda-parent/lambda/src/main/java/org/wicketstuff/lambda/table/FunctionColumn.java
@@ -4,6 +4,7 @@ import java.util.function.Function;
 
 import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.AbstractColumn;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.LambdaColumn;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.model.IModel;
@@ -20,6 +21,8 @@ import org.wicketstuff.lambda.model.LambdaModel;
  *            - the type of the sort property
  * @param <R>
  *            - type type of the cell
+ *            
+ * @deprecated use {@link LambdaColumn} instead
  */
 public class FunctionColumn<T, S, R> extends AbstractColumn<T, S> {
 


### PR DESCRIPTION
The lambda-related component and model functionality now exists in the
Wicket libraries themselves. In addition, the Serializable lambda
interfaces are now being provided by the jdk-serializable-functional
library.