### PR TITLE
fix for #588 issue on master branch

### DIFF
--- a/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/PortletFilter.java
+++ b/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/PortletFilter.java
@@ -83,6 +83,8 @@ public class PortletFilter extends WicketFilter {
 				return new PortletUrlRenderer(getRequest());
 			}
 		});
+		//fix for https://github.com/wicketstuff/core/issues/588 issue
+		getApplication().getJavaScriptLibrarySettings().setWicketAjaxReference(WicketPortletAjaxResourceReference.get());
 	}
 
 	@Override

--- a/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/ajax/WicketPortletAjaxResourceReference.java
+++ b/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/ajax/WicketPortletAjaxResourceReference.java
@@ -1,0 +1,40 @@
+package org.apache.wicket.portlet.ajax;
+
+import java.util.List;
+
+import org.apache.wicket.ajax.WicketAjaxJQueryResourceReference;
+import org.apache.wicket.markup.head.HeaderItem;
+import org.apache.wicket.markup.head.JavaScriptHeaderItem;
+import org.apache.wicket.request.resource.JavaScriptResourceReference;
+
+/**
+ * @author Konstantinos Karavitis
+ *
+ */
+public class WicketPortletAjaxResourceReference extends JavaScriptResourceReference
+{
+	private static final long serialVersionUID = 1L;
+
+	private static WicketPortletAjaxResourceReference INSTANCE = new WicketPortletAjaxResourceReference();
+
+	/**
+	 * @return the singleton INSTANCE
+	 */
+	public static WicketPortletAjaxResourceReference get()
+	{
+		return INSTANCE;
+	}
+
+	private WicketPortletAjaxResourceReference()
+	{
+		super(WicketPortletAjaxResourceReference.class, "res/js/wicket-portlet-ajax.js");
+	}
+
+	@Override
+	public List<HeaderItem> getDependencies()
+	{
+		List<HeaderItem> dependencies = super.getDependencies();
+		dependencies.add(JavaScriptHeaderItem.forReference(WicketAjaxJQueryResourceReference.get()));
+		return dependencies;
+	}
+}

--- a/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/ajax/res/js/wicket-portlet-ajax.js
+++ b/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/ajax/res/js/wicket-portlet-ajax.js
@@ -1,0 +1,37 @@
+/*
+ * Wicket Portlet Ajax support
+ * 
+ * @author Konstantinos Karavitis
+ *
+ * fix for https://github.com/wicketstuff/core/issues/588 issue
+ */
+;(function(Wicket) {
+	Wicket.Ajax.Call.prototype.processAjaxResponse = function(data, textStatus, jqXHR, context) {
+		if (jqXHR.readyState === 4) {
+			// first try to get the redirect header
+			var redirectUrl;
+			try {
+				redirectUrl = jqXHR.getResponseHeader('Ajax-Location');
+			} catch (ignore) { // might happen in older mozilla
+			}
+
+			// the redirect header was set, go to new url
+			if (typeof(redirectUrl) !== "undefined" && redirectUrl !== null && redirectUrl !== "") {
+				this.success(context);
+				context.isRedirecting = true;
+				Wicket.Ajax.redirect(redirectUrl);
+			}
+			else {
+				// no redirect, just regular response
+				if (Wicket.Log.enabled()) {
+					var responseAsText = jqXHR.responseText;
+					Wicket.Log.info("Received ajax response (" + responseAsText.length + " characters)");
+					Wicket.Log.info("\n" + responseAsText);
+				}
+
+				// invoke the loaded callback with an xml document
+				return this.loadedCallback(data, context);
+			}
+		}
+	};
+})(Wicket);


### PR DESCRIPTION
This pull request fixes the #588 issue by overriding the Wicket.Ajax.Call.prototype.processAjaxResponse in such manner as if there is a redirect url inside the 'Ajax-Location' header at the ajax response then the client/browser will redirect to this url without modifying it.