### PR TITLE
inmethodgrid: CheckBoxColumn: Fix click event name

### DIFF
--- a/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/column/CheckBoxColumn.java
+++ b/inmethod-grid-parent/inmethod-grid/src/main/java/com/inmethod/grid/column/CheckBoxColumn.java
@@ -152,7 +152,7 @@ public class CheckBoxColumn<M, I, S> extends AbstractColumn<M, I, S>
 			checkbox.setOutputMarkupId(true);
 			add(checkbox);
 
-			checkbox.add(new AjaxFormSubmitBehavior(getGrid().getForm(), "onclick")
+			checkbox.add(new AjaxFormSubmitBehavior(getGrid().getForm(), "click")
 			{
 				private static final long serialVersionUID = 1L;
 
@@ -297,7 +297,7 @@ public class CheckBoxColumn<M, I, S> extends AbstractColumn<M, I, S>
 			};
 			add(checkbox);
 
-			checkbox.add(new AjaxFormSubmitBehavior(getGrid().getForm(), "onclick")
+			checkbox.add(new AjaxFormSubmitBehavior(getGrid().getForm(), "click")
 			{
 				private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
At the moment when using the CheckBoxColumn in Wicket 7 you get spammed
with „replace onclick with click“ messages, because you get the message
for every row in which a CheckBoxColumn is displayed…

This is already fixed for Wicket 8 in master.