### PR TITLE
Expose fit markers JS

### DIFF
--- a/gmap3-parent/gmap3/src/main/java/org/wicketstuff/gmap/GMap.java
+++ b/gmap3-parent/gmap3/src/main/java/org/wicketstuff/gmap/GMap.java
@@ -792,24 +792,28 @@ public class GMap extends Panel implements GOverlayContainer
         }
     }
     
+    public String getJSFitMarkers(List<GLatLng> markers) {
+    	if (markers.isEmpty())
+    	{
+    		return "";
+    	}
+    	
+    	final StringBuilder buf = new StringBuilder();
+    	buf.append("var bounds = new google.maps.LatLngBounds();\n");
+    	// Ask google maps to keep extending the bounds to include each point
+    	for (final GLatLng point : markers)
+    	{
+    		buf.append("bounds.extend( ").append(point.getJSconstructor()).append(" );\n");
+    	}
+    	
+    	buf.append(getJSinvoke("fitBounds(bounds)"));
+    	buf.append(getJSinvoke("panToBounds(bounds)"));
+    	
+    	return buf.toString();
+    }
+    
     private String getJSFitMarkers() {
-        if (markersToShow.isEmpty())
-        {
-            return "";
-        }
-        
-        final StringBuilder buf = new StringBuilder();
-        buf.append("var bounds = new google.maps.LatLngBounds();\n");
-        // Ask google maps to keep extending the bounds to include each point
-        for (final GLatLng point : markersToShow)
-        {
-            buf.append("bounds.extend( ").append(point.getJSconstructor()).append(" );\n");
-        }
-        
-        buf.append(getJSinvoke("fitBounds(bounds)"));
-        buf.append(getJSinvoke("panToBounds(bounds)"));
-        
-        return buf.toString();
+    	return getJSFitMarkers(markersToShow);
     }
     
     private String getJSsetDraggingEnabled(final boolean enabled)


### PR DESCRIPTION
When manipulating map with AJAX - adding or removing markers, with this change it is possible to reuse JS and add it to the target so the map fits active markers 