### PR TITLE
#602 - UrlParametersReceivingBehavior does not find resource when subclassed

### DIFF
--- a/urlfragment-parent/urlfragment/src/main/java/org/wicketstuff/urlfragment/UrlParametersReceivingBehavior.java
+++ b/urlfragment-parent/urlfragment/src/main/java/org/wicketstuff/urlfragment/UrlParametersReceivingBehavior.java
@@ -89,7 +89,7 @@ public abstract class UrlParametersReceivingBehavior extends AbstractDefaultAjax
 			.append("window.UrlUtil.sendUrlParameters();")
 			.append("}catch(e){}");
 		response.render(new OnDomReadyHeaderItem(sb.toString()));
-		response.render(getJS(getClass()));
+		response.render(getJS(UrlParametersReceivingBehavior.class));
 	}
 
 	private String optionsJsonString()
@@ -117,8 +117,8 @@ public abstract class UrlParametersReceivingBehavior extends AbstractDefaultAjax
 		onParameterArrival(RequestCycle.get().getRequest().getRequestParameters(), target);
 
 		if (this.components != null)
-			addComponentsToBeRendered(target);
-	}
+            addComponentsToBeRendered(target);
+        }
 
 	@Override
 	protected void updateAjaxAttributes(AjaxRequestAttributes attributes)

--- a/urlfragment-parent/urlfragment/src/main/java/org/wicketstuff/urlfragment/UrlParametersReceivingBehavior.java
+++ b/urlfragment-parent/urlfragment/src/main/java/org/wicketstuff/urlfragment/UrlParametersReceivingBehavior.java
@@ -116,9 +116,10 @@ public abstract class UrlParametersReceivingBehavior extends AbstractDefaultAjax
 	{
 		onParameterArrival(RequestCycle.get().getRequest().getRequestParameters(), target);
 
-		if (this.components != null)
-            addComponentsToBeRendered(target);
-        }
+		if (this.components != null) {
+			addComponentsToBeRendered(target);
+		}
+	}
 
 	@Override
 	protected void updateAjaxAttributes(AjaxRequestAttributes attributes)


### PR DESCRIPTION
- Look up resource relative to UrlParametersReceivingBehavior and not relative to the actual class to allow subclasses outside the wicketstuff package