### PR TITLE
exception is not logged if json payload is invalid

### DIFF
--- a/wicketstuff-restannotations-parent/restannotations/src/main/java/org/wicketstuff/rest/resource/AbstractRestResource.java
+++ b/wicketstuff-restannotations-parent/restannotations/src/main/java/org/wicketstuff/rest/resource/AbstractRestResource.java
@@ -221,7 +221,7 @@ public abstract class AbstractRestResource<T extends IWebSerialDeserial> impleme
 		}
 		catch (RuntimeException e)
 		{
-			setResponseStatusCode(400);
+                        handleException(response, e);
 			return;
 		}
 


### PR DESCRIPTION
Also there is no way to signal back to the user of the API any json errors that arise during the extractMethodParameters call. In my case a misformed JSON caused an exception that was not logged and all the user saw was an http 400 status code. No exceptions in the logs, no error message in the response, nothing - while the handleException was implemented in the actual resource so that a uniform json error message structure was returned for all other error cases. I think routing any exception from extractMethodParameters through handleException method is a better way to do this.