### PR TITLE
Pull request for issue #621

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -674,7 +674,7 @@
 			<dependency>
 				<groupId>com.google.code.gson</groupId>
 				<artifactId>gson</artifactId>
-				<version>2.8.2</version>
+				<version>2.7</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Pull request for issue #621 "Dependency conflict problem: conflicting classes exist in different JARS"

The root cause of dependency conflict problem is that this project depends on com.google.javascript:closure-compiler:v20171203 and com.google.code.gson:gson:2.8.2, however,
com.google.javascript:closure-compiler:v20171203 is a repackaged fat JAR. By analyzing com.google.javascript:closure-compiler:v20171203, we found it contains library com.google.code.gson:gson:2.7. So that the conflicting classes occur. To solve the problem, we can harmonize the library version to com.google.code.gson:gson: 2.7, to make the world better.