### PR TITLE
Remove test library from runtime dependency path

### DIFF
--- a/javaee-inject-parent/javaee-inject/pom.xml
+++ b/javaee-inject-parent/javaee-inject/pom.xml
@@ -14,7 +14,6 @@
         <developer>
             <id>aldaris88</id>
             <name>Peter Major</name>
-            <email>majorpetya [at] sch [dot] bme [dot] hu</email>
         </developer>
     </developers>
 
@@ -32,11 +31,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
-            <version>1.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/javaee-inject-parent/javaee-inject/src/test/java/org/wicketstuff/javaee/naming/global/GlobalJndiNamingStrategyTest.java
+++ b/javaee-inject-parent/javaee-inject/src/test/java/org/wicketstuff/javaee/naming/global/GlobalJndiNamingStrategyTest.java
@@ -1,10 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.wicketstuff.javaee.naming.global;
 
-
+import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
-
 
 /**
  * The container has to register one JNDI global entry for every local and remote business interface implemented by the EJB and its no-interface view.
@@ -23,8 +36,9 @@ public class GlobalJndiNamingStrategyTest {
 
     @Test
     public void nameAccordingToSpecification() {
-        assertThat(namingStrategy.calculateName(null, String.class)).isEqualTo("java:global/appname/modulename/java.lang.String");
-        assertThat(namingStrategy.calculateName("beanname", String.class)).isEqualTo("java:global/appname/modulename/beanname!java.lang.String");
+        Assert.assertEquals(namingStrategy.calculateName(null, String.class),
+                "java:global/appname/modulename/java.lang.String");
+        Assert.assertEquals(namingStrategy.calculateName("beanname", String.class),
+                "java:global/appname/modulename/beanname!java.lang.String");
     }
-
 }


### PR DESCRIPTION
fest-assert was included with compile scope which meant that depending on this library brought in test libraries as well into applications.

The changes below remove the fest-assert usage, mainly because fest-assert is an obsolete testing library, and secondly because this was the only usage of the library across the whole project.