### PR TITLE
GChart - Correct getOptionModel() and remove unused logger

### DIFF
--- a/gchart-parent/gchart/src/main/java/org/wicketstuff/gchart/Chart.java
+++ b/gchart-parent/gchart/src/main/java/org/wicketstuff/gchart/Chart.java
@@ -293,7 +293,7 @@ public class Chart extends WebComponent implements JavaScriptable {
      *
      * @return Onle line load statement to be included in a JavaScript.
      */
-    private String createLoaderStatement() {
+    protected String createLoaderStatement() {
         StringBuilder sb = new StringBuilder();
         // Load the Visualization API and the package.
         JSONObject packageDecl = new JSONObject();
@@ -402,4 +402,10 @@ public class Chart extends WebComponent implements JavaScriptable {
         return sb.toString();
     }
 
+    /**
+     * @return the loader
+     */
+    public ChartLibLoader getLoader() {
+        return loader;
+    }   
 }

--- a/gchart-parent/gchart/src/main/java/org/wicketstuff/gchart/Chart.java
+++ b/gchart-parent/gchart/src/main/java/org/wicketstuff/gchart/Chart.java
@@ -28,8 +28,6 @@ import org.apache.wicket.markup.head.JavaScriptReferenceHeaderItem;
 import org.apache.wicket.markup.html.WebComponent;
 import org.apache.wicket.model.IComponentAssignedModel;
 import org.apache.wicket.model.IModel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.wicketstuff.gchart.gchart.options.ChartOptions;
 
 /**
@@ -41,7 +39,6 @@ import org.wicketstuff.gchart.gchart.options.ChartOptions;
 public class Chart extends WebComponent implements JavaScriptable {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger log = LoggerFactory.getLogger(Chart.class);
     /** URL for Google lib loader */
     public static final String LOADER_URL = "https://www.gstatic.com/charts/loader.js";
 
@@ -272,7 +269,7 @@ public class Chart extends WebComponent implements JavaScriptable {
     }
 
     public IModel<ChartOptions> getOptionModel() {
-        return (IModel<ChartOptions>) getDefaultModelObject();
+        return (IModel<ChartOptions>) getDefaultModel();
     }
 
     public void setOptionModel(IModel<ChartOptions> optionModel) {


### PR DESCRIPTION
getOptionModel() was returning the object and not the model, thus a ClassCastException was thrown.
I have also removed the unused logger.

Sorry for the CRLF, I'm using "core.autocrlf true", so it should be good, but it is not with this project...