### PR TITLE
Ajax redirect keeps ResponseState

### DIFF
--- a/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/WicketPortlet.java
+++ b/portlet-parent/wicketstuff-portlet/src/main/java/org/apache/wicket/portlet/WicketPortlet.java
@@ -412,23 +412,7 @@ public class WicketPortlet extends GenericPortlet {
 				// processing the request
 
 				String redirectLocation = responseState.getRedirectLocation();
-				String ajaxRedirectLocation = responseState.getAjaxRedirectLocation();
-				if (ajaxRedirectLocation != null) {
-					// Ajax redirect
-					responseState.clear();
-					responseState.setDateHeader("Date", System.currentTimeMillis());
-					responseState.setDateHeader("Expires", 0);
-					responseState.setHeader("Pragma", "no-cache");
-					responseState.setHeader("Cache-Control", "no-cache, no-store");
-					//client side javascript needs the Ajax-Location header see wicket-ajax-jquery.js line 771
-					responseState.setHeader("Ajax-Location", ajaxRedirectLocation);//
-					responseState.setContentType("text/xml;charset=UTF-8");
-					responseState.getWriter().write(
-						"<ajax-response><redirect><![CDATA[" + ajaxRedirectLocation +
-							"]]></redirect></ajax-response>");
-					responseState.flushAndClose();
-				}
-				else if (redirectLocation != null) {
+				if (redirectLocation != null) {
 					// TODO: check if its redirect to wicket page (find _wu or
 					// _wuPortletMode or resourceId parameter)
 
@@ -510,7 +494,7 @@ public class WicketPortlet extends GenericPortlet {
 				}
 				else {
 					if (LOG.isDebugEnabled()) {
-						LOG.debug("ajax redirect url after inclusion:" + redirectLocation);
+						LOG.debug("ajax redirect url after inclusion:" + responseState.getAjaxRedirectLocation());
 					}
 					// write response state out to the PortletResponse
 					responseState.flushAndClose();


### PR DESCRIPTION
Ajax redirect now correctly keep all response state, including cookies, and is not cleared before flushed.
Related to https://github.com/wicketstuff/core/issues/650