### PR TITLE
Allow to customize selectize.js settings

### DIFF
--- a/wicketstuff-selectize-parent/wicketstuff-selectize/src/main/java/org/wicketstuff/selectize/Selectize.java
+++ b/wicketstuff-selectize-parent/wicketstuff-selectize/src/main/java/org/wicketstuff/selectize/Selectize.java
@@ -251,7 +251,7 @@ public class Selectize extends FormComponent
 			}
 
 			Map<String, String> variablesMap = new HashMap<>();
-			variablesMap.put("selectizeConfig", selectizeConfig.toString());
+			variablesMap.put("selectizeConfig", extendConfig(selectizeConfig).toString());
 			response.render(OnDomReadyHeaderItem.forScript(packageTextTemplate.asString(variablesMap)));
 		}
 		catch (Exception e)
@@ -268,6 +268,11 @@ public class Selectize extends FormComponent
 		response.render(JavaScriptHeaderItem.forScript("Wicket.Ajax.baseUrl=\"" + ajaxBaseUrl +
 			"\";", "wicket-ajax-base-url"));
 
+	}
+
+	protected JSONObject extendConfig(JSONObject config)
+	{
+		return config;
 	}
 
 	@Override


### PR DESCRIPTION
Selectize.js has a bunch of configurations, that are useful or must be tweaked. We need this to be able to enable the 'remove_button' plugin and overwrite some texts with localized strings.