### PR TITLE
Select2 stateless displaying initial values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .metadata
 .settings
 .project
+.factorypath
 target/
 .classpath
 *.i[mpw][lrs]

--- a/select2-parent/select2-examples/src/main/java/org/wicketstuff/select2/HomePage.java
+++ b/select2-parent/select2-examples/src/main/java/org/wicketstuff/select2/HomePage.java
@@ -55,6 +55,8 @@ public class HomePage extends WebPage
 	private List<Country> countriesListMultipleChoice = new ArrayList<>(Arrays.asList(new Country[] { Country.US, Country.CA }));
 	@SuppressWarnings("unused")
 	private List<String> tags = new ArrayList<>(Arrays.asList("tag1", "tag2"));
+	@SuppressWarnings("unused")
+	private List<Country> countriesStateless = new ArrayList<>(Arrays.asList(new Country[] { Country.US, Country.CA }));
 
 	public HomePage()
 	{
@@ -189,7 +191,8 @@ public class HomePage extends WebPage
 		Form<Void> stateless = new Form<>("stateless");
 		add(stateless);
 
-		final Select2MultiChoice<Country> statelessCountries = new Select2MultiChoice<Country>("statelessCountries")
+		final Select2MultiChoice<Country> statelessCountries = new Select2MultiChoice<Country>("statelessCountries",
+			new PropertyModel<Collection<Country>>(this, "countriesStateless"), new CountriesProvider())
 		{
 			private static final long serialVersionUID = 1L;
 

--- a/select2-parent/select2/src/main/java/org/wicketstuff/select2/AbstractSelect2Choice.java
+++ b/select2-parent/select2/src/main/java/org/wicketstuff/select2/AbstractSelect2Choice.java
@@ -430,7 +430,7 @@ public abstract class AbstractSelect2Choice<T, M> extends FormComponent<M> imple
 	@Override
 	public void onComponentTagBody(final MarkupStream markupStream, final ComponentTag openTag)
 	{
-		if (getSettings().isStateless()) {
+		if (provider == null) {
 			super.onComponentTagBody(markupStream, openTag);
 		} else {
 			final AppendingStringBuffer buffer = new AppendingStringBuffer();


### PR DESCRIPTION
Select2Choice components always display initial values, except when Settings.setStateless(true) is used (field is always empty). This is because field construction uses getSettings().isStateless() to decide when filling initial values.

This problematic behavior can be seen in the updated examples provided by this PR. Without our fix, stateless example is empty despite providing initial values.

I think Select2Choice initial values should also displays (if a provider is available). I propose to fix this by modifying onComponentTagBody so that it can use the given provider, even if Settings.setStateless(true) is called.

With this fix, we can handle Settings.setStateless(true) + initial values selection, by providing : 

- A provider Select2 that can display initial values
- A mountPath to access the external provider (which is the actual behavior)
- A model with initial values

This pull request also updates the stateless Select2 example field. It is now filled with initial values which is consistent with the other examples.

Separately from the main subject, I saw that the .gitignore was provided with Eclipse files to ignore. I added ".factorypath" files that are also created by Eclipse.