### PR TITLE
JamonMonitoredRequestCycleTest fails on Windows in case JVMs are reused.

### DIFF
--- a/jamon-parent/jamon/pom.xml
+++ b/jamon-parent/jamon/pom.xml
@@ -11,6 +11,22 @@
 	<name>Jamon</name>
 	<description>An integration of Jamon API with Apache Wicket</description>
 
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>${maven-surefire-plugin.version}</version>
+					<configuration>
+						<!-- https://github.com/wicketstuff/core/issues/676 -->
+						<reuseForks>false</reuseForks>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+
 	<dependencies>
 		<!-- WICKET -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1179,7 +1179,6 @@
 						<includes>
 							<include>**/*Test.java</include>
 						</includes>
-						<reuseForks>false</reuseForks>
 						<testFailureIgnore>false</testFailureIgnore>
 						<argLine>-Xmx1G --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-modules=ALL-SYSTEM</argLine>
 					</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1179,6 +1179,7 @@
 						<includes>
 							<include>**/*Test.java</include>
 						</includes>
+						<reuseForks>false</reuseForks>
 						<testFailureIgnore>false</testFailureIgnore>
 						<argLine>-Xmx1G --add-opens java.base/jdk.internal.loader=ALL-UNNAMED --add-modules=ALL-SYSTEM</argLine>
 					</configuration>


### PR DESCRIPTION
Surefire reuses forked JVMs by default, which makes JamonMonitoredRequestCycleTest.shouldNotMonitorJamonAdminPageItSelf fail on Windows for some currently unknown reason. Disabling reusing of JVMs for Surefire for this special project makes the build succeed. Disabling reusing JVMs for whole Wicket Stuff makes the build fail instead, because tests of the project quickview fail then.

This fixes #676.