### PR TITLE
"reuseForks" doesn't seem to resolve the issue reliably.

### DIFF
--- a/jamon-parent/jamon/pom.xml
+++ b/jamon-parent/jamon/pom.xml
@@ -20,7 +20,7 @@
 					<version>${maven-surefire-plugin.version}</version>
 					<configuration>
 						<!-- https://github.com/wicketstuff/core/issues/676 -->
-						<reuseForks>false</reuseForks>
+						<forkedProcessExitTimeoutInSeconds>200</forkedProcessExitTimeoutInSeconds>
 					</configuration>
 				</plugin>
 			</plugins>

--- a/jamon-parent/jamon/pom.xml
+++ b/jamon-parent/jamon/pom.xml
@@ -20,7 +20,7 @@
 					<version>${maven-surefire-plugin.version}</version>
 					<configuration>
 						<!-- https://github.com/wicketstuff/core/issues/676 -->
-						<forkedProcessExitTimeoutInSeconds>200</forkedProcessExitTimeoutInSeconds>
+						<forkedProcessExitTimeoutInSeconds>500</forkedProcessExitTimeoutInSeconds>
 					</configuration>
 				</plugin>
 			</plugins>


### PR DESCRIPTION
Increasing the timeout used by Surefire to exit forked JVMs does. Switching between 2 and 200 seconds makes the build reliably fail or succeed and in the latter case it's runtime is around ~80 to ~90 seconds as well. That is much higher than before in case of failing tests and even when they did succeed using "reuseForks" set to "false".

This fixes #676.