### PR TITLE
Bootstrap version 3

### DIFF
--- a/openlayers3-parent/openlayers3-bootstrap/pom.xml
+++ b/openlayers3-parent/openlayers3-bootstrap/pom.xml
@@ -41,6 +41,7 @@
         <dependency>
             <groupId>de.agilecoders.wicket</groupId>
             <artifactId>wicket-bootstrap-core</artifactId>
+            <version>[4.0.0-M1,5.0.0-M1)</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Overlays (and popups) in OpenLayers3 depends on Bootstrap 3 (wicket-bootstrap-core version 4). OL3 cannot run on Bootstrap 4. I have tested that configuration with Wicket 9.