### PR TITLE
[wicketstuff-input-events] 'disable_in_input' would handle the contenteditable="true" attribute

### DIFF
--- a/input-events-parent/input-events/src/main/java/wicket/contrib/input/events/shortcut.js
+++ b/input-events-parent/input-events/src/main/java/wicket/contrib/input/events/shortcut.js
@@ -37,7 +37,7 @@ shortcut = {
 				else if(e.srcElement) element=e.srcElement;
 				if(element.nodeType==3) element=element.parentNode;
 
-				if(element.tagName == 'INPUT' || element.tagName == 'TEXTAREA') return;
+				if(element.tagName == 'INPUT' || element.tagName == 'TEXTAREA' || element.getAttribute('contenteditable') == 'true') return;
 			}
 	
 			//Find Which key is pressed


### PR DESCRIPTION
issue: https://github.com/wicketstuff/core/issues/730