### PR TITLE
bump jasperreports to 6.20.3 and explicitly depend on openpdf

### DIFF
--- a/jasperreports-parent/jasperreports/pom.xml
+++ b/jasperreports-parent/jasperreports/pom.xml
@@ -35,6 +35,10 @@
 			<artifactId>jasperreports</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.github.librepdf</groupId>
+			<artifactId>openpdf</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId><!-- required to override bundled version -->
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,8 @@
 		<jts.version>1.13</jts.version>
 		<gson.version>2.10.1</gson.version>
 		<wicket-bootstrap-core.version>4.0.4</wicket-bootstrap-core.version> <!-- 4.0.x is required for openlayers-3 (bootstrap3) -->
-		<jasperreports.version>6.20.1</jasperreports.version>
+		<jasperreports.version>6.20.2</jasperreports.version>
+		<openpdf.version>1.3.30.jaspersoft.2</openpdf.version>
 		<bcprov.version>1.70</bcprov.version>
 		<joda-time.version>2.12.5</joda-time.version>
 		<ehcache.version>3.10.8</ehcache.version>
@@ -428,6 +429,13 @@
 			<artifactId>wicket-core</artifactId>
 		</dependency>
 	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>jaspersoft-third-party</id>
+			<url>https://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/</url>
+		</repository>
+	</repositories>
 
 	<dependencyManagement>
 		<dependencies>
@@ -812,6 +820,11 @@
 				<groupId>net.sf.jasperreports</groupId>
 				<artifactId>jasperreports</artifactId>
 				<version>${jasperreports.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.librepdf</groupId>
+				<artifactId>openpdf</artifactId>
+				<version>${openpdf.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -306,7 +306,7 @@
 		<jts.version>1.13</jts.version>
 		<gson.version>2.10.1</gson.version>
 		<wicket-bootstrap-core.version>4.0.4</wicket-bootstrap-core.version> <!-- 4.0.x is required for openlayers-3 (bootstrap3) -->
-		<jasperreports.version>6.20.2</jasperreports.version>
+		<jasperreports.version>6.20.3</jasperreports.version>
 		<openpdf.version>1.3.30.jaspersoft.2</openpdf.version>
 		<bcprov.version>1.70</bcprov.version>
 		<joda-time.version>2.12.5</joda-time.version>

--- a/pom.xml
+++ b/pom.xml
@@ -431,6 +431,7 @@
 	</dependencies>
 
 	<repositories>
+		<!-- Required for jasperreports-specific version of openpdf -->
 		<repository>
 			<id>jaspersoft-third-party</id>
 			<url>https://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/</url>


### PR DESCRIPTION
jasperreports in version 6.20.2 made the dependency on openpdf optional (see [pom](https://github.com/TIBCOSoftware/jasperreports/blob/302f46434bc66c04d8a4cde60a4333904ae36507/jasperreports/pom.xml#L68)), thus not bringing in openpdf as a transitive dependency to consuming projects anymore.

It seems that in how we use jasperreports via wicketstuff does need openpdf. I worked around it in my project by explicitly depending on the library (see [here](https://github.com/ursjoss/scipamato/pull/486/files)).

However, IMHO it would be convenient to have wicketstuff declare the dependency instead of the consumers.

Note that this not only adds to the maintenance cost of dependency management in wicketstuff, it also introduces a new repository, as jasperreports maintains their own version of the library, which is not present in maven central.

So please consider if this additional burden is worth the effort. I could understand if you don't want to accept that.

Thanks for evaluating it.