### PR TITLE
bump jasperreports to 6.20.4 and fall back to transitive dependency on openpdf

### DIFF
--- a/jasperreports-parent/jasperreports/pom.xml
+++ b/jasperreports-parent/jasperreports/pom.xml
@@ -35,10 +35,6 @@
 			<artifactId>jasperreports</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.github.librepdf</groupId>
-			<artifactId>openpdf</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId><!-- required to override bundled version -->
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -306,8 +306,7 @@
 		<jts.version>1.13</jts.version>
 		<gson.version>2.10.1</gson.version>
 		<wicket-bootstrap-core.version>4.0.4</wicket-bootstrap-core.version> <!-- 4.0.x is required for openlayers-3 (bootstrap3) -->
-		<jasperreports.version>6.20.3</jasperreports.version>
-		<openpdf.version>1.3.30.jaspersoft.2</openpdf.version>
+		<jasperreports.version>6.20.4</jasperreports.version>
 		<bcprov.version>1.70</bcprov.version>
 		<joda-time.version>2.12.5</joda-time.version>
 		<ehcache.version>3.10.8</ehcache.version>
@@ -429,14 +428,6 @@
 			<artifactId>wicket-core</artifactId>
 		</dependency>
 	</dependencies>
-
-	<repositories>
-		<!-- Required for jasperreports-specific version of openpdf -->
-		<repository>
-			<id>jaspersoft-third-party</id>
-			<url>https://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts/</url>
-		</repository>
-	</repositories>
 
 	<dependencyManagement>
 		<dependencies>
@@ -821,11 +812,6 @@
 				<groupId>net.sf.jasperreports</groupId>
 				<artifactId>jasperreports</artifactId>
 				<version>${jasperreports.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>com.github.librepdf</groupId>
-				<artifactId>openpdf</artifactId>
-				<version>${openpdf.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>joda-time</groupId>


### PR DESCRIPTION
With version [jasperreports-6.20.4](https://github.com/TIBCOSoftware/jasperreports/compare/6.20.3...6.20.4), Jasperreports reverted to make openpdf mandatory again - as it was before 6.20.2.

With this, we can remove the additional complexity (introduced in #749) with the extra repo and explicit dependency on openpdf.

As discussed [here](https://github.com/TIBCOSoftware/jasperreports/issues/351), this topic might come back later, potentially with jasperreports 7.0.0.
