### PR TITLE
Remove unused bcprov-jdk18on dependency

### DIFF
--- a/jasperreports-parent/jasperreports/pom.xml
+++ b/jasperreports-parent/jasperreports/pom.xml
@@ -34,10 +34,6 @@
 			<groupId>net.sf.jasperreports</groupId>
 			<artifactId>jasperreports</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcprov-jdk18on</artifactId><!-- required to override bundled version -->
-		</dependency>
 
 		<!-- Provided -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,6 @@
 		<gson.version>2.10.1</gson.version>
 		<wicket-bootstrap-core.version>7.0.3</wicket-bootstrap-core.version>
 		<jasperreports.version>6.21.2</jasperreports.version>
-		<bcprov.version>1.78</bcprov.version>
 		<joda-time.version>2.12.7</joda-time.version>
 		<ehcache.version>3.10.8</ehcache.version>
 		<jakartaee-api.version>10.0.0</jakartaee-api.version>
@@ -947,11 +946,6 @@
 				<artifactId>hamcrest-library</artifactId>
 				<version>${hamcrest.version}</version>
 				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.bouncycastle</groupId>
-				<artifactId>bcprov-jdk18on</artifactId>
-				<version>${bcprov.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>


### PR DESCRIPTION
There is no bundled `bcprov-jdk18on` dependency in Jasperreports or any of its transitive dependencies according to `mvn dependency:tree`.