### PR TITLE
#1007 Do not bind session as a side effect when removing pages

### DIFF
--- a/datastores-parent/datastore-common/src/main/java/org/wicketstuff/datastores/common/SessionQuotaManagingDataStore.java
+++ b/datastores-parent/datastore-common/src/main/java/org/wicketstuff/datastores/common/SessionQuotaManagingDataStore.java
@@ -66,14 +66,7 @@ public class SessionQuotaManagingDataStore extends DelegatingPageStore {
 
 	private SessionData getSessionData(IPageContext context, boolean create)
 	{
-		return context.getSessionData(KEY, () -> {
-			if (create)
-			{
-				return dataCreator.get();
-			}
-			
-			return null;
-		});
+		return context.getSessionData(KEY, create ? dataCreator : null);
 	}
 
 	@Override

--- a/datastores-parent/datastore-tests/pom.xml
+++ b/datastores-parent/datastore-tests/pom.xml
@@ -76,5 +76,10 @@
 			<artifactId>websocket-jakarta-server</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/datastores-parent/datastore-tests/pom.xml
+++ b/datastores-parent/datastore-tests/pom.xml
@@ -79,6 +79,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/datastores-parent/datastore-tests/pom.xml
+++ b/datastores-parent/datastore-tests/pom.xml
@@ -79,7 +79,6 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/datastores-parent/datastore-tests/pom.xml
+++ b/datastores-parent/datastore-tests/pom.xml
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
-			<scope>test</scope>
+			<scope>compile</scope>
 		</dependency>
 	</dependencies>
 </project>

--- a/datastores-parent/datastore-tests/src/main/java/org/wicketstuff/datastores/common/SessionQuotaManagingDataStoreTest.java
+++ b/datastores-parent/datastore-tests/src/main/java/org/wicketstuff/datastores/common/SessionQuotaManagingDataStoreTest.java
@@ -3,6 +3,7 @@ package org.wicketstuff.datastores.common;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 

--- a/datastores-parent/datastore-tests/src/main/java/org/wicketstuff/datastores/common/SessionQuotaManagingDataStoreTest.java
+++ b/datastores-parent/datastore-tests/src/main/java/org/wicketstuff/datastores/common/SessionQuotaManagingDataStoreTest.java
@@ -1,7 +1,12 @@
 package org.wicketstuff.datastores.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
+import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.mock.MockPageContext;
 import org.apache.wicket.mock.MockPageStore;
 import org.apache.wicket.pageStore.IPageContext;
@@ -91,5 +96,17 @@ public class SessionQuotaManagingDataStoreTest {
 		assertEquals(2, delegate.getPages().size());
 		assertEquals(page1, delegate.getPages().get(0));
 		assertEquals(page3, delegate.getPages().get(1));
+	}
+
+	@Test
+	public void removePageShouldNotSupplyDefaultValueWhenGettingSessionData() {
+		MockPageStore delegate = new MockPageStore();
+
+		IPageContext context = mock(IPageContext.class);
+
+		IPageStore quotaStore = new SessionQuotaManagingDataStore(delegate, Bytes.bytes(page1.getData().length + page3.getData().length));
+		quotaStore.removePage(context, page1);
+		
+		verify(context).getSessionData(any(MetaDataKey.class), eq(null));
 	}
 }


### PR DESCRIPTION
This PR passes `null` instead of a  null-supplier when pages are removed from a `SessionQuotaManagingDataStore`. This prevents binding the session as a side-effect.

Resolves #1007.