### PR TITLE
Resolve build warnings displayed at the start of the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,10 +350,6 @@
 		<maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
 	</properties>
 
-	<prerequisites>
-		<maven>3.5.0</maven>
-	</prerequisites>
-
 	<modules>
 		<module>offline-mode-parent</module>
 		<module>nashorn-parent</module>
@@ -1042,6 +1038,25 @@
 			</testResource>
 		</testResources>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>enforce-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>3.5.0</version>
+								</requireMavenVersion>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>

--- a/wicket-security-parent/pom.xml
+++ b/wicket-security-parent/pom.xml
@@ -27,9 +27,6 @@
 	<name>wicket-security</name>
 	<inceptionYear>2006</inceptionYear>
 	<description>Parent project for wicket security projects</description>
-	<prerequisites>
-		<maven>2.1</maven>
-	</prerequisites>
 	<!-- Developers -->
 	<developers>
 		<developer>

--- a/wicketstuff-jquery-ui-parent/wicketstuff-jquery-ui-samples/pom.xml
+++ b/wicketstuff-jquery-ui-parent/wicketstuff-jquery-ui-samples/pom.xml
@@ -169,5 +169,14 @@
 				</configuration>
 			</plugin>
  		</plugins>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.sonatype.plugins</groupId>
+					<artifactId>nexus-staging-maven-plugin</artifactId>
+					<version>1.7.0</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 </project>


### PR DESCRIPTION
These changes should get rid of these build warnings:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.wicketstuff:wicketstuff-jquery-ui-samples:war:10.3.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.sonatype.plugins:nexus-staging-maven-plugin is missing. @ line 150, column 12
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[WARNING] The project org.wicketstuff:wicketstuff-core:pom:10.3.0-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
[WARNING] The project org.wicketstuff:wicket-security-parent:pom:10.3.0-SNAPSHOT uses prerequisites which is only intended for maven-plugin projects but not for non maven-plugin projects. For such purposes you should use the maven-enforcer-plugin. See https://maven.apache.org/enforcer/enforcer-rules/requireMavenVersion.html
```