### PR TITLE
feat(gmap3-parent): allow subclasses to customize InfoWindow initialization

### DIFF
--- a/gmap3-parent/gmap3/src/main/java/org/wicketstuff/gmap/api/GInfoWindow.java
+++ b/gmap3-parent/gmap3/src/main/java/org/wicketstuff/gmap/api/GInfoWindow.java
@@ -101,8 +101,19 @@ public class GInfoWindow extends GOverlay
             args.set("zIndex", zIndex.toString());
         }
         
+        configureJSconstructor(args);
+        
         Constructor constructor = new Constructor("google.maps.InfoWindow").add(args.toJS());
         return constructor.toJS();
+    }
+    
+    /**
+     * Allow subclasses to customize InfoWindow initialization.
+     * 
+     * @param args
+     */
+    protected void configureJSconstructor(ObjectLiteral args) 
+    {
     }
 
     /**


### PR DESCRIPTION
Customizing a constructor, such as adding InfoWindow header, means recreating the logic of `getJSconstructor()` which is cumbersome. This addition allows hooking own modifications easily.