### PR TITLE
Remove hard dependency logger implementation `jcl-over-slf4j`

### DIFF
--- a/jasperreports-parent/jasperreports/pom.xml
+++ b/jasperreports-parent/jasperreports/pom.xml
@@ -23,12 +23,6 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 
-		<!-- Inherited -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
-		</dependency>
-
 		<!-- Module-specific -->
 		<dependency>
 			<groupId>net.sf.jasperreports</groupId>


### PR DESCRIPTION
It should be up to the application to decide which logging implementation to use and where the various facades direct their logging.

The `<optional>` tag is not inherited from the `<dependencyManagement>` section in the parent POMs.

See https://github.com/apache/maven/issues/6974
See https://github.com/apache/maven/issues/6692