### PR TITLE
Fixing setup of resource name when loading i18n resources

### DIFF
--- a/select2-parent/select2/src/main/java/org/wicketstuff/select2/Select2LanguageResourceReference.java
+++ b/select2-parent/select2/src/main/java/org/wicketstuff/select2/Select2LanguageResourceReference.java
@@ -1,5 +1,7 @@
 package org.wicketstuff.select2;
 
+import de.agilecoders.wicket.webjars.request.resource.WebjarsJavaScriptResourceReference;
+
 import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
 /**
@@ -8,16 +10,17 @@ import org.apache.wicket.request.resource.JavaScriptResourceReference;
  *
  * @author Tom Götz (tom@decoded.de)
  */
-class Select2LanguageResourceReference extends JavaScriptResourceReference {
+class Select2LanguageResourceReference extends WebjarsJavaScriptResourceReference {
 	private static final long serialVersionUID = 1L;
-	private static final String resourceName = "res/js/i18n/%s.js";
+	//private static final String resourceName = "res/js/i18n/%s.js";
+	private static final String resourceName = "select2/current/dist/js/i18n/%s.js";
     private static final String defaultLanguage = "en";
 
     /**
      * @param language i18n file to load (e.g. "en", "de", "fr" ...)
      */
     Select2LanguageResourceReference(String language) {
-        super(Select2LanguageResourceReference.class, getResourceName(language));
+        super(getResourceName(language));
     }
 
     /**
@@ -30,7 +33,7 @@ class Select2LanguageResourceReference extends JavaScriptResourceReference {
     private static String getResourceName(String language) {
         try {
             String name = String.format(resourceName, language);
-            if (Select2LanguageResourceReference.class.getResource(name) != null) {
+            if (WebjarsJavaScriptResourceReference.class.getResource(name) != null) {
                 return name;
             }
         } catch (Exception ignore) {

--- a/select2-parent/select2/src/main/java/org/wicketstuff/select2/Select2LanguageResourceReference.java
+++ b/select2-parent/select2/src/main/java/org/wicketstuff/select2/Select2LanguageResourceReference.java
@@ -2,6 +2,7 @@ package org.wicketstuff.select2;
 
 import de.agilecoders.wicket.webjars.request.resource.WebjarsJavaScriptResourceReference;
 
+import static org.apache.wicket.util.string.Strings.isEmpty;
 import org.apache.wicket.request.resource.JavaScriptResourceReference;
 
 /**
@@ -12,7 +13,6 @@ import org.apache.wicket.request.resource.JavaScriptResourceReference;
  */
 class Select2LanguageResourceReference extends WebjarsJavaScriptResourceReference {
 	private static final long serialVersionUID = 1L;
-	//private static final String resourceName = "res/js/i18n/%s.js";
 	private static final String resourceName = "select2/current/dist/js/i18n/%s.js";
     private static final String defaultLanguage = "en";
 
@@ -31,14 +31,10 @@ class Select2LanguageResourceReference extends WebjarsJavaScriptResourceReferenc
      * @return resource name
      */
     private static String getResourceName(String language) {
-        try {
-            String name = String.format(resourceName, language);
-            if (WebjarsJavaScriptResourceReference.class.getResource(name) != null) {
-                return name;
-            }
-        } catch (Exception ignore) {
-            // noop
+        if (isEmpty(language)) {
+            return String.format(resourceName, defaultLanguage);
         }
-        return String.format(resourceName, defaultLanguage);
+
+        return String.format(resourceName, language);
     }
 }


### PR DESCRIPTION
Checking whether a resource file exists does not work with Webjars
as previously implemented. The new check is now a simple implementation
whether the given language string is empty or not.